### PR TITLE
QF1100 Summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# MacOS file
+.DS_Store
+
+# Local file
+*.local.*

--- a/NUS/QF1100/summary/Lecture 01.md
+++ b/NUS/QF1100/summary/Lecture 01.md
@@ -188,11 +188,7 @@ $$
 The accumulation formulas are:
 
 $$
-\begin{aligned}
-a\left(\frac{1}{p}\right) &= 1 + \frac{r^{(p)}}{p}, \\
-a(1) &= \left(1 + \frac{r^{(p)}}{p}\right)^p, \\
-a(t) &= \left(1 + \frac{r^{(p)}}{p}\right)^{pt}.
-\end{aligned}
+\begin{aligned} a\left(\frac{1}{p}\right) &= 1 + \frac{r^{(p)}}{p}, \\ a(1) &= \left(1 + \frac{r^{(p)}}{p}\right)^p, \\ a(t) &= \left(1 + \frac{r^{(p)}}{p}\right)^{pt}. \end{aligned}
 $$
 
 Common values:
@@ -292,9 +288,7 @@ Two nominal rates are equivalent if they produce the same one-year
 accumulation.
 
 $$
-\left(1 + \frac{r^{(p)}}{p}\right)^p
-=
-\left(1 + \frac{R^{(q)}}{q}\right)^q
+\left(1 + \frac{r^{(p)}}{p}\right)^p = \left(1 + \frac{R^{(q)}}{q}\right)^q
 $$
 
 Use this when converting between compounding frequencies.
@@ -368,8 +362,7 @@ the same exponential form.
 The force of interest is the instantaneous relative growth rate.
 
 $$
-\delta(t) = \frac{a'(t)}{a(t)}
-= \frac{d}{dt}\left[\ln a(t)\right]
+\delta(t) = \frac{a'(t)}{a(t)} = \frac{d}{dt}\left[\ln a(t)\right]
 $$
 
 If $\delta(t) = \delta$ is constant, then:
@@ -428,8 +421,7 @@ $$
 For accumulation from time $s$ to time $t$:
 
 $$
-a(s,t) = \frac{a(t)}{a(s)}
-= \exp\left(\int_s^t \delta(u)\,du\right)
+a(s,t) = \frac{a(t)}{a(s)} = \exp\left(\int_s^t \delta(u)\,du\right)
 $$
 
 <details>
@@ -467,8 +459,7 @@ $\frac{a(t)}{a(s)} = \frac{ \exp(\int_0^t \delta(u)\,du) }{ \exp(\int_0^s \delta
 For $t_0 < t_1 < t_2 < \cdots < t_n$:
 
 $$
-a(t_0,t_n)
-= a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n)
+a(t_0,t_n) = a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n)
 $$
 
 <details>

--- a/NUS/QF1100/summary/Lecture 01.md
+++ b/NUS/QF1100/summary/Lecture 01.md
@@ -1,0 +1,608 @@
+# Lecture 01 - Theory of Interest
+
+This lecture introduces how money grows over time under different interest
+conventions.
+
+## Variable Definitions
+
+Unless stated otherwise, time is measured in years.
+
+$$
+P = \text{principal, or initial amount invested}
+$$
+
+$$
+A(t) = \text{accumulated amount at time } t
+$$
+
+$$
+a(t) = \text{accumulation function for one unit of money}
+$$
+
+$$
+t = \text{time elapsed}
+$$
+
+$$
+r = \text{interest rate under the stated compounding convention}
+$$
+
+$$
+r^{(p)} = \text{nominal annual interest rate compounded } p \text{ times per year}
+$$
+
+$$
+p = \text{number of compounding periods per year}
+$$
+
+$$
+r_e = \text{effective annual interest rate}
+$$
+
+$$
+R^{(q)} = \text{another nominal annual rate compounded } q \text{ times per year}
+$$
+
+$$
+q = \text{another compounding frequency}
+$$
+
+$$
+x = \text{dummy variable used for compounding frequency in limits or proofs}
+$$
+
+$$
+e = \text{Euler's number, used for continuous compounding}
+$$
+
+$$
+\delta(t) = \text{force of interest at time } t
+$$
+
+$$
+\delta = \text{constant force of interest}
+$$
+
+$$
+a'(t) = \text{derivative of } a(t) \text{ with respect to } t
+$$
+
+$$
+a(s,t) = \text{accumulation factor from time } s \text{ to time } t
+$$
+
+The variable $s$ is a starting time in $a(s,t)$. The variable $u$ is a
+dummy time variable used inside integrals.
+The variables $t_0,t_1,\ldots,t_n$ are ordered time points in the
+consistency principle.
+
+## Core Accumulation
+
+If $P$ is the principal and $a(t)$ is the accumulation function:
+
+$$
+A(t) = P a(t), \qquad a(0) = 1
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The accumulation function $a(t)$ tells us what one unit of money becomes
+after time $t$.
+
+So if one unit becomes $a(t)$, then $P$ units become:
+
+$$
+P \times a(t)
+$$
+
+Hence:
+
+$$
+A(t) = Pa(t)
+$$
+
+Also, at time $0$, no time has passed, so one unit is still one unit:
+
+$$
+a(0)=1
+$$
+
+</details>
+
+## Simple Interest
+
+Simple interest is earned only on the principal.
+
+$$
+a(t) = 1 + rt
+$$
+
+where $r$ is the annual interest rate.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Under simple interest, interest does not earn further interest.
+
+After $t$ years, the interest earned on principal $P$ is:
+
+$$
+Prt
+$$
+
+So the accumulated amount is:
+
+$$
+A(t) = P + Prt = P(1+rt)
+$$
+
+Since:
+
+$$
+A(t)=Pa(t)
+$$
+
+we get:
+
+$$
+a(t)=1+rt
+$$
+
+Simple interest grows linearly because the interest is always based only
+on the original principal.
+
+</details>
+
+## Compound Interest
+
+Interest earned after one period is reinvested.
+
+$$
+a(t) = (1+r)^t
+$$
+
+Unless stated otherwise, QF1100 assumes compound interest.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Under compound interest, each period multiplies the current amount by:
+
+$$
+1+r
+$$
+
+After one period:
+
+$$
+a(1)=1+r
+$$
+
+After two periods:
+
+$$
+a(2)=(1+r)(1+r)=(1+r)^2
+$$
+
+After $t$ years, when $r$ is the effective annual rate:
+
+$$
+a(t)=(1+r)^t
+$$
+
+For positive $r$, compound interest matches simple interest at $t=1$ and
+exceeds it for $t>1$ because interest is added back into the balance and
+earns more interest later. For $0<t<1$, under $a(t)=(1+r)^t$, compound
+accumulation is lower than simple accumulation.
+
+</details>
+
+## Nominal Rate Compounded $p$ Times Per Year
+
+If the nominal annual rate is $r^{(p)}$ and interest is compounded $p$
+times per year:
+
+$$
+\text{periodic rate} = \frac{r^{(p)}}{p}
+$$
+
+The accumulation formulas are:
+
+$$
+\begin{aligned}
+a\left(\frac{1}{p}\right) &= 1 + \frac{r^{(p)}}{p}, \\
+a(1) &= \left(1 + \frac{r^{(p)}}{p}\right)^p, \\
+a(t) &= \left(1 + \frac{r^{(p)}}{p}\right)^{pt}.
+\end{aligned}
+$$
+
+Common values:
+
+- $p = 2$: semi-annual compounding
+- $p = 4$: quarterly compounding
+- $p = 12$: monthly compounding
+
+<details>
+<summary>Intuition / proof</summary>
+
+The nominal annual rate $r^{(p)}$ is split evenly across $p$ compounding
+periods in a year.
+
+So the interest rate per compounding period is:
+
+$$
+\frac{r^{(p)}}{p}
+$$
+
+Each compounding period multiplies money by:
+
+$$
+1+\frac{r^{(p)}}{p}
+$$
+
+There are $p$ compounding periods in one year, so:
+
+$$
+a(1)=\left(1+\frac{r^{(p)}}{p}\right)^p
+$$
+
+There are $pt$ compounding periods in $t$ years, so:
+
+$$
+a(t)=\left(1+\frac{r^{(p)}}{p}\right)^{pt}
+$$
+
+</details>
+
+## Effective Annual Interest Rate
+
+The effective annual interest rate $r_e$ is the actual one-year growth
+rate.
+
+$$
+1 + r_e = \left(1 + \frac{r^{(p)}}{p}\right)^p
+$$
+
+Equivalently:
+
+$$
+r_e = \left(1 + \frac{r^{(p)}}{p}\right)^p - 1
+$$
+
+For positive rates and integer $p \ge 1$:
+
+$$
+r_e \ge r^{(p)}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The effective annual rate asks: what single annual rate gives the same
+one-year growth?
+
+For a nominal rate compounded $p$ times per year, one-year accumulation
+is:
+
+$$
+\left(1+\frac{r^{(p)}}{p}\right)^p
+$$
+
+For an effective annual rate, one-year accumulation is:
+
+$$
+1+r_e
+$$
+
+Equating the two gives:
+
+$$
+1+r_e=\left(1+\frac{r^{(p)}}{p}\right)^p
+$$
+
+For $r^{(p)} \ge 0$, the inequality $r_e \ge r^{(p)}$ comes from the fact
+that compounding adds interest on interest.
+
+Algebraically, let:
+
+$$
+x=\frac{r^{(p)}}{p}
+$$
+
+Then:
+
+$$
+(1+x)^p \ge 1+px
+$$
+
+So:
+
+$$
+\left(1+\frac{r^{(p)}}{p}\right)^p
+\ge
+1+r^{(p)}
+$$
+
+Subtracting $1$ gives:
+
+$$
+r_e \ge r^{(p)}
+$$
+
+</details>
+
+## Equivalent Nominal Rates
+
+Two nominal rates are equivalent if they produce the same one-year
+accumulation.
+
+$$
+\left(1 + \frac{r^{(p)}}{p}\right)^p
+=
+\left(1 + \frac{R^{(q)}}{q}\right)^q
+$$
+
+Use this when converting between compounding frequencies.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Equivalent rates must make the same amount of money after one year.
+
+The nominal rate $r^{(p)}$ compounded $p$ times per year gives:
+
+$$
+\left(1+\frac{r^{(p)}}{p}\right)^p
+$$
+
+The nominal rate $R^{(q)}$ compounded $q$ times per year gives:
+
+$$
+\left(1+\frac{R^{(q)}}{q}\right)^q
+$$
+
+If these two one-year accumulation factors are equal, then both rates are
+financially equivalent over one year.
+
+</details>
+
+## Continuous Compounding
+
+As the compounding frequency tends to infinity:
+
+$$
+\lim_{x \to \infty} \left(1 + \frac{r}{x}\right)^x = e^r
+$$
+
+For continuous compounding:
+
+$$
+a(1) = e^r, \qquad a(t) = e^{rt}
+$$
+
+Here $r$ is the continuously compounded rate.
+
+Equivalence with a nominal rate compounded $p$ times per year:
+
+$$
+\left(1 + \frac{r^{(p)}}{p}\right)^p = e^r = 1 + r_e
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Continuous compounding is the limiting case of compounding more and more
+frequently.
+
+With $x$ compounding periods per year, the one-year accumulation is:
+
+$$
+\left(1+\frac{r}{x}\right)^x
+$$
+
+As $x$ becomes infinitely large, the compounding periods become
+infinitesimally small. The limit is:
+
+$$
+e^r
+$$
+
+For $t$ years, the same logic gives:
+
+$$
+a(t)=e^{rt}
+$$
+
+This is why continuous compounding and a constant force of interest use
+the same exponential form.
+
+</details>
+
+## Force of Interest
+
+The force of interest is the instantaneous relative growth rate.
+
+$$
+\delta(t) = \frac{a'(t)}{a(t)}
+= \frac{d}{dt}\left[\ln a(t)\right]
+$$
+
+If $\delta(t) = \delta$ is constant, then:
+
+$$
+a(t) = e^{\delta t}
+$$
+
+So a constant force of interest is the same idea as a continuously
+compounded rate.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The derivative $a'(t)$ measures the instantaneous rate at which the
+accumulation function is changing.
+
+Dividing by $a(t)$ turns this into a relative growth rate:
+
+$$
+\frac{a'(t)}{a(t)}
+$$
+
+That relative growth rate is the force of interest:
+
+$$
+\delta(t)=\frac{a'(t)}{a(t)}
+$$
+
+Also:
+
+$$
+\frac{d}{dt}\ln a(t)=\frac{a'(t)}{a(t)}
+$$
+
+If the force is constant, then:
+
+$$
+\frac{d}{dt}\ln a(t)=\delta
+$$
+
+Integrating from $0$ to $t$ gives:
+
+$$
+\ln a(t)-\ln a(0)=\delta t
+$$
+
+Since $a(0)=1$, we have $\ln a(0)=0$, so:
+
+$$
+\ln a(t)=\delta t
+$$
+
+Therefore:
+
+$$
+a(t)=e^{\delta t}
+$$
+
+</details>
+
+## Recovering Accumulation from Force of Interest
+
+If the force of interest is known:
+
+$$
+a(t) = \exp\left(\int_0^t \delta(u)\,du\right)
+$$
+
+For accumulation from time $s$ to time $t$:
+
+$$
+a(s,t) = \frac{a(t)}{a(s)}
+= \exp\left(\int_s^t \delta(u)\,du\right)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+From the definition of force of interest:
+
+$$
+\delta(t)=\frac{d}{dt}\ln a(t)
+$$
+
+Integrate both sides from $0$ to $t$:
+
+$$
+\int_0^t \delta(u)\,du
+=
+\ln a(t)-\ln a(0)
+$$
+
+Since $a(0)=1$, $\ln a(0)=0$, so:
+
+$$
+\ln a(t)=\int_0^t \delta(u)\,du
+$$
+
+Exponentiating both sides gives:
+
+$$
+a(t)=\exp\left(\int_0^t \delta(u)\,du\right)
+$$
+
+For accumulation from $s$ to $t$, divide the total accumulation to time
+$t$ by the total accumulation to time $s$:
+
+$$
+a(s,t)=\frac{a(t)}{a(s)}
+$$
+
+Using the force-of-interest formula:
+
+$$
+\frac{a(t)}{a(s)}
+=
+\frac{
+\exp\left(\int_0^t \delta(u)\,du\right)
+}{
+\exp\left(\int_0^s \delta(u)\,du\right)
+}
+=
+\exp\left(\int_s^t \delta(u)\,du\right)
+$$
+
+</details>
+
+## Consistency Principle
+
+For $t_0 < t_1 < t_2 < \cdots < t_n$:
+
+$$
+a(t_0,t_n)
+= a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Accumulating from $t_0$ to $t_n$ should be the same as accumulating in
+smaller consecutive steps.
+
+Using:
+
+$$
+a(s,t)=\frac{a(t)}{a(s)}
+$$
+
+we get:
+
+$$
+a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n)
+=
+\frac{a(t_1)}{a(t_0)}
+\frac{a(t_2)}{a(t_1)}
+\cdots
+\frac{a(t_n)}{a(t_{n-1})}
+$$
+
+All middle terms cancel, leaving:
+
+$$
+\frac{a(t_n)}{a(t_0)}
+=a(t_0,t_n)
+$$
+
+So the consistency principle is just the idea that growth over a long
+interval can be split into consecutive shorter intervals.
+
+</details>
+
+## Must Remember
+
+- Simple interest grows linearly: $a(t) = 1 + rt$.
+- Compound interest grows exponentially: $a(t) = (1+r)^t$.
+- Effective rate converts nominal compounding into actual annual growth.
+- Equivalent rates have the same one-year accumulation.
+- Continuous compounding uses $e^{rt}$.
+- Force of interest is $\delta(t) = a'(t) / a(t)$.

--- a/NUS/QF1100/summary/Lecture 01.md
+++ b/NUS/QF1100/summary/Lecture 01.md
@@ -362,7 +362,7 @@ the same exponential form.
 The force of interest is the instantaneous relative growth rate.
 
 $$
-\delta(t) = \frac{a'(t)}{a(t)} = \frac{d}{dt}\left[\ln a(t)\right]
+\delta(t) = \frac{a'(t)}{a(t)} = \frac{d}{dt}\ln a(t)
 $$
 
 If $\delta(t) = \delta$ is constant, then:

--- a/NUS/QF1100/summary/Lecture 01.md
+++ b/NUS/QF1100/summary/Lecture 01.md
@@ -92,15 +92,15 @@ after time $t$.
 
 So if one unit becomes $a(t)$, then $P$ units become:
 
-$\displaystyle P \times a(t)$
+$P \times a(t)$
 
 Hence:
 
-$\displaystyle A(t) = Pa(t)$
+$A(t) = Pa(t)$
 
 Also, at time $0$, no time has passed, so one unit is still one unit:
 
-$\displaystyle a(0)=1$
+$a(0)=1$
 
 </details>
 
@@ -121,19 +121,19 @@ Under simple interest, interest does not earn further interest.
 
 After $t$ years, the interest earned on principal $P$ is:
 
-$\displaystyle Prt$
+$Prt$
 
 So the accumulated amount is:
 
-$\displaystyle A(t) = P + Prt = P(1+rt)$
+$A(t) = P + Prt = P(1+rt)$
 
 Since:
 
-$\displaystyle A(t)=Pa(t)$
+$A(t)=Pa(t)$
 
 we get:
 
-$\displaystyle a(t)=1+rt$
+$a(t)=1+rt$
 
 Simple interest grows linearly because the interest is always based only
 on the original principal.
@@ -155,19 +155,19 @@ Unless stated otherwise, QF1100 assumes compound interest.
 
 Under compound interest, each period multiplies the current amount by:
 
-$\displaystyle 1+r$
+$1+r$
 
 After one period:
 
-$\displaystyle a(1)=1+r$
+$a(1)=1+r$
 
 After two periods:
 
-$\displaystyle a(2)=(1+r)(1+r)=(1+r)^2$
+$a(2)=(1+r)(1+r)=(1+r)^2$
 
 After $t$ years, when $r$ is the effective annual rate:
 
-$\displaystyle a(t)=(1+r)^t$
+$a(t)=(1+r)^t$
 
 For positive $r$, compound interest matches simple interest at $t=1$ and
 exceeds it for $t>1$ because interest is added back into the balance and
@@ -209,19 +209,19 @@ periods in a year.
 
 So the interest rate per compounding period is:
 
-$\displaystyle \frac{r^{(p)}}{p}$
+$\frac{r^{(p)}}{p}$
 
 Each compounding period multiplies money by:
 
-$\displaystyle 1+\frac{r^{(p)}}{p}$
+$1+\frac{r^{(p)}}{p}$
 
 There are $p$ compounding periods in one year, so:
 
-$\displaystyle a(1)=\left(1+\frac{r^{(p)}}{p}\right)^p$
+$a(1)=(1+\frac{r^{(p)}}{p})^p$
 
 There are $pt$ compounding periods in $t$ years, so:
 
-$\displaystyle a(t)=\left(1+\frac{r^{(p)}}{p}\right)^{pt}$
+$a(t)=(1+\frac{r^{(p)}}{p})^{pt}$
 
 </details>
 
@@ -255,34 +255,34 @@ one-year growth?
 For a nominal rate compounded $p$ times per year, one-year accumulation
 is:
 
-$\displaystyle \left(1+\frac{r^{(p)}}{p}\right)^p$
+$(1+\frac{r^{(p)}}{p})^p$
 
 For an effective annual rate, one-year accumulation is:
 
-$\displaystyle 1+r_e$
+$1+r_e$
 
 Equating the two gives:
 
-$\displaystyle 1+r_e=\left(1+\frac{r^{(p)}}{p}\right)^p$
+$1+r_e=(1+\frac{r^{(p)}}{p})^p$
 
 For $r^{(p)} \ge 0$, the inequality $r_e \ge r^{(p)}$ comes from the fact
 that compounding adds interest on interest.
 
 Algebraically, let:
 
-$\displaystyle x=\frac{r^{(p)}}{p}$
+$x=\frac{r^{(p)}}{p}$
 
 Then:
 
-$\displaystyle (1+x)^p \ge 1+px$
+$(1+x)^p \ge 1+px$
 
 So:
 
-$\displaystyle \left(1+\frac{r^{(p)}}{p}\right)^p \ge 1+r^{(p)}$
+$(1+\frac{r^{(p)}}{p})^p \ge 1+r^{(p)}$
 
 Subtracting $1$ gives:
 
-$\displaystyle r_e \ge r^{(p)}$
+$r_e \ge r^{(p)}$
 
 </details>
 
@@ -306,11 +306,11 @@ Equivalent rates must make the same amount of money after one year.
 
 The nominal rate $r^{(p)}$ compounded $p$ times per year gives:
 
-$\displaystyle \left(1+\frac{r^{(p)}}{p}\right)^p$
+$(1+\frac{r^{(p)}}{p})^p$
 
 The nominal rate $R^{(q)}$ compounded $q$ times per year gives:
 
-$\displaystyle \left(1+\frac{R^{(q)}}{q}\right)^q$
+$(1+\frac{R^{(q)}}{q})^q$
 
 If these two one-year accumulation factors are equal, then both rates are
 financially equivalent over one year.
@@ -347,16 +347,16 @@ frequently.
 
 With $x$ compounding periods per year, the one-year accumulation is:
 
-$\displaystyle \left(1+\frac{r}{x}\right)^x$
+$(1+\frac{r}{x})^x$
 
 As $x$ becomes infinitely large, the compounding periods become
 infinitesimally small. The limit is:
 
-$\displaystyle e^r$
+$e^r$
 
 For $t$ years, the same logic gives:
 
-$\displaystyle a(t)=e^{rt}$
+$a(t)=e^{rt}$
 
 This is why continuous compounding and a constant force of interest use
 the same exponential form.
@@ -389,31 +389,31 @@ accumulation function is changing.
 
 Dividing by $a(t)$ turns this into a relative growth rate:
 
-$\displaystyle \frac{a'(t)}{a(t)}$
+$\frac{a'(t)}{a(t)}$
 
 That relative growth rate is the force of interest:
 
-$\displaystyle \delta(t)=\frac{a'(t)}{a(t)}$
+$\delta(t)=\frac{a'(t)}{a(t)}$
 
 Also:
 
-$\displaystyle \frac{d}{dt}\ln a(t)=\frac{a'(t)}{a(t)}$
+$\frac{d}{dt}\ln a(t)=\frac{a'(t)}{a(t)}$
 
 If the force is constant, then:
 
-$\displaystyle \frac{d}{dt}\ln a(t)=\delta$
+$\frac{d}{dt}\ln a(t)=\delta$
 
 Integrating from $0$ to $t$ gives:
 
-$\displaystyle \ln a(t)-\ln a(0)=\delta t$
+$\ln a(t)-\ln a(0)=\delta t$
 
 Since $a(0)=1$, we have $\ln a(0)=0$, so:
 
-$\displaystyle \ln a(t)=\delta t$
+$\ln a(t)=\delta t$
 
 Therefore:
 
-$\displaystyle a(t)=e^{\delta t}$
+$a(t)=e^{\delta t}$
 
 </details>
 
@@ -437,28 +437,28 @@ $$
 
 From the definition of force of interest:
 
-$\displaystyle \delta(t)=\frac{d}{dt}\ln a(t)$
+$\delta(t)=\frac{d}{dt}\ln a(t)$
 
 Integrate both sides from $0$ to $t$:
 
-$\displaystyle \int_0^t \delta(u)\,du = \ln a(t)-\ln a(0)$
+$\int_0^t \delta(u)\,du = \ln a(t)-\ln a(0)$
 
 Since $a(0)=1$, $\ln a(0)=0$, so:
 
-$\displaystyle \ln a(t)=\int_0^t \delta(u)\,du$
+$\ln a(t)=\int_0^t \delta(u)\,du$
 
 Exponentiating both sides gives:
 
-$\displaystyle a(t)=\exp\left(\int_0^t \delta(u)\,du\right)$
+$a(t)=\exp(\int_0^t \delta(u)\,du)$
 
 For accumulation from $s$ to $t$, divide the total accumulation to time
 $t$ by the total accumulation to time $s$:
 
-$\displaystyle a(s,t)=\frac{a(t)}{a(s)}$
+$a(s,t)=\frac{a(t)}{a(s)}$
 
 Using the force-of-interest formula:
 
-$\displaystyle \frac{a(t)}{a(s)} = \frac{ \exp\left(\int_0^t \delta(u)\,du\right) }{ \exp\left(\int_0^s \delta(u)\,du\right) } = \exp\left(\int_s^t \delta(u)\,du\right)$
+$\frac{a(t)}{a(s)} = \frac{ \exp(\int_0^t \delta(u)\,du) }{ \exp(\int_0^s \delta(u)\,du) } = \exp(\int_s^t \delta(u)\,du)$
 
 </details>
 
@@ -479,15 +479,15 @@ smaller consecutive steps.
 
 Using:
 
-$\displaystyle a(s,t)=\frac{a(t)}{a(s)}$
+$a(s,t)=\frac{a(t)}{a(s)}$
 
 we get:
 
-$\displaystyle a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n) = \frac{a(t_1)}{a(t_0)} \frac{a(t_2)}{a(t_1)} \cdots \frac{a(t_n)}{a(t_{n-1})}$
+$a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n) = \frac{a(t_1)}{a(t_0)} \frac{a(t_2)}{a(t_1)} \cdots \frac{a(t_n)}{a(t_{n-1})}$
 
 All middle terms cancel, leaving:
 
-$\displaystyle \frac{a(t_n)}{a(t_0)} =a(t_0,t_n)$
+$\frac{a(t_n)}{a(t_0)} =a(t_0,t_n)$
 
 So the consistency principle is just the idea that growth over a long
 interval can be split into consecutive shorter intervals.

--- a/NUS/QF1100/summary/Lecture 01.md
+++ b/NUS/QF1100/summary/Lecture 01.md
@@ -92,21 +92,15 @@ after time $t$.
 
 So if one unit becomes $a(t)$, then $P$ units become:
 
-$$
-P \times a(t)
-$$
+$\displaystyle P \times a(t)$
 
 Hence:
 
-$$
-A(t) = Pa(t)
-$$
+$\displaystyle A(t) = Pa(t)$
 
 Also, at time $0$, no time has passed, so one unit is still one unit:
 
-$$
-a(0)=1
-$$
+$\displaystyle a(0)=1$
 
 </details>
 
@@ -127,27 +121,19 @@ Under simple interest, interest does not earn further interest.
 
 After $t$ years, the interest earned on principal $P$ is:
 
-$$
-Prt
-$$
+$\displaystyle Prt$
 
 So the accumulated amount is:
 
-$$
-A(t) = P + Prt = P(1+rt)
-$$
+$\displaystyle A(t) = P + Prt = P(1+rt)$
 
 Since:
 
-$$
-A(t)=Pa(t)
-$$
+$\displaystyle A(t)=Pa(t)$
 
 we get:
 
-$$
-a(t)=1+rt
-$$
+$\displaystyle a(t)=1+rt$
 
 Simple interest grows linearly because the interest is always based only
 on the original principal.
@@ -169,27 +155,19 @@ Unless stated otherwise, QF1100 assumes compound interest.
 
 Under compound interest, each period multiplies the current amount by:
 
-$$
-1+r
-$$
+$\displaystyle 1+r$
 
 After one period:
 
-$$
-a(1)=1+r
-$$
+$\displaystyle a(1)=1+r$
 
 After two periods:
 
-$$
-a(2)=(1+r)(1+r)=(1+r)^2
-$$
+$\displaystyle a(2)=(1+r)(1+r)=(1+r)^2$
 
 After $t$ years, when $r$ is the effective annual rate:
 
-$$
-a(t)=(1+r)^t
-$$
+$\displaystyle a(t)=(1+r)^t$
 
 For positive $r$, compound interest matches simple interest at $t=1$ and
 exceeds it for $t>1$ because interest is added back into the balance and
@@ -231,27 +209,19 @@ periods in a year.
 
 So the interest rate per compounding period is:
 
-$$
-\frac{r^{(p)}}{p}
-$$
+$\displaystyle \frac{r^{(p)}}{p}$
 
 Each compounding period multiplies money by:
 
-$$
-1+\frac{r^{(p)}}{p}
-$$
+$\displaystyle 1+\frac{r^{(p)}}{p}$
 
 There are $p$ compounding periods in one year, so:
 
-$$
-a(1)=\left(1+\frac{r^{(p)}}{p}\right)^p
-$$
+$\displaystyle a(1)=\left(1+\frac{r^{(p)}}{p}\right)^p$
 
 There are $pt$ compounding periods in $t$ years, so:
 
-$$
-a(t)=\left(1+\frac{r^{(p)}}{p}\right)^{pt}
-$$
+$\displaystyle a(t)=\left(1+\frac{r^{(p)}}{p}\right)^{pt}$
 
 </details>
 
@@ -285,50 +255,34 @@ one-year growth?
 For a nominal rate compounded $p$ times per year, one-year accumulation
 is:
 
-$$
-\left(1+\frac{r^{(p)}}{p}\right)^p
-$$
+$\displaystyle \left(1+\frac{r^{(p)}}{p}\right)^p$
 
 For an effective annual rate, one-year accumulation is:
 
-$$
-1+r_e
-$$
+$\displaystyle 1+r_e$
 
 Equating the two gives:
 
-$$
-1+r_e=\left(1+\frac{r^{(p)}}{p}\right)^p
-$$
+$\displaystyle 1+r_e=\left(1+\frac{r^{(p)}}{p}\right)^p$
 
 For $r^{(p)} \ge 0$, the inequality $r_e \ge r^{(p)}$ comes from the fact
 that compounding adds interest on interest.
 
 Algebraically, let:
 
-$$
-x=\frac{r^{(p)}}{p}
-$$
+$\displaystyle x=\frac{r^{(p)}}{p}$
 
 Then:
 
-$$
-(1+x)^p \ge 1+px
-$$
+$\displaystyle (1+x)^p \ge 1+px$
 
 So:
 
-$$
-\left(1+\frac{r^{(p)}}{p}\right)^p
-\ge
-1+r^{(p)}
-$$
+$\displaystyle \left(1+\frac{r^{(p)}}{p}\right)^p \ge 1+r^{(p)}$
 
 Subtracting $1$ gives:
 
-$$
-r_e \ge r^{(p)}
-$$
+$\displaystyle r_e \ge r^{(p)}$
 
 </details>
 
@@ -352,15 +306,11 @@ Equivalent rates must make the same amount of money after one year.
 
 The nominal rate $r^{(p)}$ compounded $p$ times per year gives:
 
-$$
-\left(1+\frac{r^{(p)}}{p}\right)^p
-$$
+$\displaystyle \left(1+\frac{r^{(p)}}{p}\right)^p$
 
 The nominal rate $R^{(q)}$ compounded $q$ times per year gives:
 
-$$
-\left(1+\frac{R^{(q)}}{q}\right)^q
-$$
+$\displaystyle \left(1+\frac{R^{(q)}}{q}\right)^q$
 
 If these two one-year accumulation factors are equal, then both rates are
 financially equivalent over one year.
@@ -397,22 +347,16 @@ frequently.
 
 With $x$ compounding periods per year, the one-year accumulation is:
 
-$$
-\left(1+\frac{r}{x}\right)^x
-$$
+$\displaystyle \left(1+\frac{r}{x}\right)^x$
 
 As $x$ becomes infinitely large, the compounding periods become
 infinitesimally small. The limit is:
 
-$$
-e^r
-$$
+$\displaystyle e^r$
 
 For $t$ years, the same logic gives:
 
-$$
-a(t)=e^{rt}
-$$
+$\displaystyle a(t)=e^{rt}$
 
 This is why continuous compounding and a constant force of interest use
 the same exponential form.
@@ -445,45 +389,31 @@ accumulation function is changing.
 
 Dividing by $a(t)$ turns this into a relative growth rate:
 
-$$
-\frac{a'(t)}{a(t)}
-$$
+$\displaystyle \frac{a'(t)}{a(t)}$
 
 That relative growth rate is the force of interest:
 
-$$
-\delta(t)=\frac{a'(t)}{a(t)}
-$$
+$\displaystyle \delta(t)=\frac{a'(t)}{a(t)}$
 
 Also:
 
-$$
-\frac{d}{dt}\ln a(t)=\frac{a'(t)}{a(t)}
-$$
+$\displaystyle \frac{d}{dt}\ln a(t)=\frac{a'(t)}{a(t)}$
 
 If the force is constant, then:
 
-$$
-\frac{d}{dt}\ln a(t)=\delta
-$$
+$\displaystyle \frac{d}{dt}\ln a(t)=\delta$
 
 Integrating from $0$ to $t$ gives:
 
-$$
-\ln a(t)-\ln a(0)=\delta t
-$$
+$\displaystyle \ln a(t)-\ln a(0)=\delta t$
 
 Since $a(0)=1$, we have $\ln a(0)=0$, so:
 
-$$
-\ln a(t)=\delta t
-$$
+$\displaystyle \ln a(t)=\delta t$
 
 Therefore:
 
-$$
-a(t)=e^{\delta t}
-$$
+$\displaystyle a(t)=e^{\delta t}$
 
 </details>
 
@@ -507,50 +437,28 @@ $$
 
 From the definition of force of interest:
 
-$$
-\delta(t)=\frac{d}{dt}\ln a(t)
-$$
+$\displaystyle \delta(t)=\frac{d}{dt}\ln a(t)$
 
 Integrate both sides from $0$ to $t$:
 
-$$
-\int_0^t \delta(u)\,du
-=
-\ln a(t)-\ln a(0)
-$$
+$\displaystyle \int_0^t \delta(u)\,du = \ln a(t)-\ln a(0)$
 
 Since $a(0)=1$, $\ln a(0)=0$, so:
 
-$$
-\ln a(t)=\int_0^t \delta(u)\,du
-$$
+$\displaystyle \ln a(t)=\int_0^t \delta(u)\,du$
 
 Exponentiating both sides gives:
 
-$$
-a(t)=\exp\left(\int_0^t \delta(u)\,du\right)
-$$
+$\displaystyle a(t)=\exp\left(\int_0^t \delta(u)\,du\right)$
 
 For accumulation from $s$ to $t$, divide the total accumulation to time
 $t$ by the total accumulation to time $s$:
 
-$$
-a(s,t)=\frac{a(t)}{a(s)}
-$$
+$\displaystyle a(s,t)=\frac{a(t)}{a(s)}$
 
 Using the force-of-interest formula:
 
-$$
-\frac{a(t)}{a(s)}
-=
-\frac{
-\exp\left(\int_0^t \delta(u)\,du\right)
-}{
-\exp\left(\int_0^s \delta(u)\,du\right)
-}
-=
-\exp\left(\int_s^t \delta(u)\,du\right)
-$$
+$\displaystyle \frac{a(t)}{a(s)} = \frac{ \exp\left(\int_0^t \delta(u)\,du\right) }{ \exp\left(\int_0^s \delta(u)\,du\right) } = \exp\left(\int_s^t \delta(u)\,du\right)$
 
 </details>
 
@@ -571,27 +479,15 @@ smaller consecutive steps.
 
 Using:
 
-$$
-a(s,t)=\frac{a(t)}{a(s)}
-$$
+$\displaystyle a(s,t)=\frac{a(t)}{a(s)}$
 
 we get:
 
-$$
-a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n)
-=
-\frac{a(t_1)}{a(t_0)}
-\frac{a(t_2)}{a(t_1)}
-\cdots
-\frac{a(t_n)}{a(t_{n-1})}
-$$
+$\displaystyle a(t_0,t_1)a(t_1,t_2)\cdots a(t_{n-1},t_n) = \frac{a(t_1)}{a(t_0)} \frac{a(t_2)}{a(t_1)} \cdots \frac{a(t_n)}{a(t_{n-1})}$
 
 All middle terms cancel, leaving:
 
-$$
-\frac{a(t_n)}{a(t_0)}
-=a(t_0,t_n)
-$$
+$\displaystyle \frac{a(t_n)}{a(t_0)} =a(t_0,t_n)$
 
 So the consistency principle is just the idea that growth over a long
 interval can be split into consecutive shorter intervals.

--- a/NUS/QF1100/summary/Lecture 01.md
+++ b/NUS/QF1100/summary/Lecture 01.md
@@ -598,7 +598,7 @@ interval can be split into consecutive shorter intervals.
 
 </details>
 
-## Must Remember
+## Key Takeaways
 
 - Simple interest grows linearly: $a(t) = 1 + rt$.
 - Compound interest grows exponentially: $a(t) = (1+r)^t$.

--- a/NUS/QF1100/summary/Lecture 02.md
+++ b/NUS/QF1100/summary/Lecture 02.md
@@ -544,7 +544,7 @@ $$
 Its present value at $t = 0$ is:
 
 $$
-\mathrm{PV} = \sum_{j=1}^n \frac{A}{(1+r)^j} = \frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
+\mathrm{PV} = \sum_{j=1}^n \frac{A}{(1+r)^j} = \frac{A}{r}\left(1-\frac{1}{(1+r)^n}\right)
 $$
 
 An annuity due has payments at the beginning of each period:
@@ -556,7 +556,7 @@ $$
 Its present value at $t = 0$ is:
 
 $$
-\mathrm{PV} = \sum_{j=0}^{n-1} \frac{A}{(1+r)^j} = \frac{A(1+r)}{r}\left[1-\frac{1}{(1+r)^n}\right]
+\mathrm{PV} = \sum_{j=0}^{n-1} \frac{A}{(1+r)^j} = \frac{A(1+r)}{r}\left(1-\frac{1}{(1+r)^n}\right)
 $$
 
 Relationship:
@@ -645,7 +645,7 @@ $$
 For equal end-of-period payments $A$ over $n$ periods:
 
 $$
-L = \frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
+L = \frac{A}{r}\left(1-\frac{1}{(1+r)^n}\right)
 $$
 
 So:
@@ -693,7 +693,7 @@ $$
 Using the annuity formula:
 
 $$
-L_m^{\text{Bal}} = \frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]
+L_m^{\text{Bal}} = \frac{A}{r}\left(1-\frac{1}{(1+r)^{n-m}}\right)
 $$
 
 This method does not require the original loan amount $L$.
@@ -704,14 +704,14 @@ This looks backward. Accumulate the original loan to time $m$, then
 subtract the accumulated value of the payments already made.
 
 $$
-L_m^{\text{Bal}} = L(1+r)^m - \frac{A}{r}\left[(1+r)^m - 1\right]
+L_m^{\text{Bal}} = L(1+r)^m - \frac{A}{r}\left((1+r)^m - 1\right)
 $$
 
 Equivalently, as written using the ordinary annuity PV factor accumulated
 to time $m$:
 
 $$
-L_m^{\text{Bal}} = L(1+r)^m - \frac{A}{r}\left[1-\frac{1}{(1+r)^m}\right](1+r)^m
+L_m^{\text{Bal}} = L(1+r)^m - \frac{A}{r}\left(1-\frac{1}{(1+r)^m}\right)(1+r)^m
 $$
 
 This method requires the original loan amount $L$.

--- a/NUS/QF1100/summary/Lecture 02.md
+++ b/NUS/QF1100/summary/Lecture 02.md
@@ -1,0 +1,888 @@
+# Lecture 02
+
+This lecture explains how to compare cash flows that occur at different
+times by moving their values to a common time.
+
+Assume $a(t)$ is the accumulation function. When the effective interest
+rate per period is constant, write it as $r$.
+
+## Variable Definitions
+
+Unless stated otherwise, time is measured in periods matching the interest
+rate.
+
+$$
+a(t) = \text{accumulation function from time } 0 \text{ to time } t
+$$
+
+$$
+r = \text{effective interest rate per period}
+$$
+
+$$
+c = \text{single cash flow amount}
+$$
+
+$$
+t = \text{time at which a cash flow is valued or paid}
+$$
+
+$$
+C = \text{cash flow stream}
+$$
+
+$$
+D = \text{another cash flow stream used for comparison}
+$$
+
+$$
+c_i = \text{amount of the } i\text{th cash flow}
+$$
+
+$$
+t_i = \text{time of the } i\text{th cash flow}
+$$
+
+$$
+n = \text{number of cash flows or payments}
+$$
+
+$$
+i = \text{index for cash flows}
+$$
+
+$$
+j = \text{index used in annuity or perpetuity payment sums}
+$$
+
+$$
+\operatorname{PV}(C) = \text{present value of cash flow stream } C
+$$
+
+$$
+\operatorname{TV}_t(C) = \text{time value of } C \text{ at time } t
+$$
+
+$$
+s = \text{another time point used when moving values between times}
+$$
+
+$$
+\operatorname{NPV}(C) = \text{net present value of cash flow stream } C
+$$
+
+$$
+(c_0,c_1,\ldots,c_n) = \text{signed cash flows at integer times } 0,1,\ldots,n
+$$
+
+$$
+x = \frac{1}{1+r}
+$$
+
+$$
+\operatorname{IRR} = \text{internal rate of return}
+$$
+
+$$
+f(z) = \text{function whose root is being approximated}
+$$
+
+$$
+z = \text{input variable for } f(z)
+$$
+
+$$
+f'(z) = \text{derivative of } f(z)
+$$
+
+$$
+\alpha_k = \text{Newton-Raphson approximation after } k \text{ iterations}
+$$
+
+$$
+k = \text{index for Newton-Raphson iterations or cash-flow conditions}
+$$
+
+$$
+A = \text{annuity or loan payment per period}
+$$
+
+$$
+L = \text{original loan amount}
+$$
+
+$$
+m = \text{number of loan payments already made}
+$$
+
+$$
+L_m^{\text{Bal}} = \text{loan balance immediately after the } m\text{th payment}
+$$
+
+For formulas with $\frac{1}{r}$, assume $r \ne 0$. In most financial
+settings here, $r>0$.
+
+## Present Value
+
+Present value asks: how much is a future payment worth today?
+
+For a single payment $c$ at time $t \ge 0$:
+
+$$
+\operatorname{PV} = \frac{c}{a(t)}
+$$
+
+If the effective interest rate is $r$:
+
+$$
+\operatorname{PV} = \frac{c}{(1+r)^t}
+$$
+
+For a cash flow stream
+
+$$
+C = \{(c_1,t_1),(c_2,t_2),\ldots,(c_n,t_n)\},
+$$
+
+the present value is:
+
+$$
+\operatorname{PV}(C) = \sum_{i=1}^n \frac{c_i}{a(t_i)}
+$$
+
+If the effective interest rate is $r$:
+
+$$
+\operatorname{PV}(C) = \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i}}
+$$
+
+Finding the present value of a future payment is called discounting.
+
+<details>
+<summary>Intuition / proof</summary>
+
+If one unit at time $0$ grows to $a(t)$ units at time $t$, then the amount
+at time $0$ that grows to $c$ at time $t$ must be:
+
+$$
+\frac{c}{a(t)}
+$$
+
+because:
+
+$$
+\frac{c}{a(t)}a(t)=c
+$$
+
+When the effective interest rate is constant:
+
+$$
+a(t)=(1+r)^t
+$$
+
+so:
+
+$$
+\operatorname{PV}=\frac{c}{(1+r)^t}
+$$
+
+For a stream of cash flows, present value is additive. Each cash flow is
+discounted to time $0$, then added:
+
+$$
+\operatorname{PV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}
+$$
+
+</details>
+
+## Time Value
+
+The time value of cash flow $C$ at time $t$, denoted $\operatorname{TV}_t(C)$,
+is:
+
+$$
+\operatorname{TV}_t(C) = \operatorname{PV}(C)a(t)
+$$
+
+For $0 < s < t$:
+
+$$
+\operatorname{TV}_t(C)
+= \frac{a(t)}{a(s)}\operatorname{TV}_s(C)
+$$
+
+If the effective interest rate is $r$:
+
+$$
+\operatorname{TV}_t(C)
+= \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i-t}}
+$$
+
+and:
+
+$$
+\operatorname{TV}_t(C) = \operatorname{TV}_s(C)(1+r)^{t-s}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The present value of $C$ is its value at time $0$. To move that value to
+time $t$, accumulate it by $a(t)$:
+
+$$
+\operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)
+$$
+
+To move from time $s$ to time $t$, multiply by the accumulation factor
+from $s$ to $t$:
+
+$$
+a(s,t)=\frac{a(t)}{a(s)}
+$$
+
+So:
+
+$$
+\operatorname{TV}_t(C)
+=\frac{a(t)}{a(s)}\operatorname{TV}_s(C)
+$$
+
+When $a(t)=(1+r)^t$:
+
+$$
+\frac{a(t)}{a(s)}
+=\frac{(1+r)^t}{(1+r)^s}
+=(1+r)^{t-s}
+$$
+
+For each cash flow $c_i$ at time $t_i$, its value at time $t$ is:
+
+$$
+\frac{c_i}{(1+r)^{t_i-t}}
+$$
+
+If $t_i>t$, this discounts backward. If $t_i<t$, the exponent is negative,
+so the expression accumulates forward.
+
+</details>
+
+## Principle of Equivalence
+
+Two cash flow streams are equivalent if and only if they have the same
+present value, assuming the interest rate and accumulation method are the
+same.
+
+Equivalent cash flow streams also have the same time value at any time
+$t$.
+
+<details>
+<summary>Intuition / proof</summary>
+
+If two cash flow streams $C$ and $D$ have the same present value, say:
+
+$$
+\operatorname{PV}(C)=\operatorname{PV}(D)
+$$
+
+then their time values at time $t$ are:
+
+$$
+\operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)
+$$
+
+and:
+
+$$
+\operatorname{TV}_t(D)=\operatorname{PV}(D)a(t)
+$$
+
+Since the present values are equal, the time values are also equal.
+
+So equality at one time implies equality at every time, as long as the
+same accumulation method is used.
+
+</details>
+
+## Net Present Value
+
+Net present value, or $\operatorname{NPV}$, is the present value of all cash
+flows in an investment project, including both negative and positive cash
+flows.
+
+For an investment cash flow
+
+$$
+C = \{(c_i,t_i)\}_{i=1}^n,
+$$
+
+the net present value is:
+
+$$
+\operatorname{NPV}(C) = \sum_{i=1}^n \frac{c_i}{a(t_i)}
+$$
+
+If the effective interest rate is $r$:
+
+$$
+\operatorname{NPV}(C) = \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i}}
+$$
+
+Decision rules:
+
+- Invest if $\operatorname{NPV} > 0$.
+- Project A is preferred to Project B if $\operatorname{NPV}(A) > \operatorname{NPV}(B)$.
+
+<details>
+<summary>Intuition / proof</summary>
+
+NPV is just present value applied to signed cash flows.
+
+Positive cash flows are benefits and negative cash flows are costs.
+Discount every cash flow to time $0$, then add:
+
+$$
+\operatorname{NPV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}
+$$
+
+If $\operatorname{NPV}>0$, the benefits are worth more today than the
+costs, using the chosen discount rate.
+
+</details>
+
+## Equation of Value
+
+An equation of value compares two cash flow streams by moving them to the
+same focal time and setting those values equal.
+
+At time $0$, if cash flow streams $C$ and $D$ are equivalent, then:
+
+$$
+\operatorname{PV}(C)=\operatorname{PV}(D)
+$$
+
+For a cash flow stream written as $(c_0,c_1,\ldots,c_n)$ at integer
+times, a common special case is the equation of value against the zero
+cash flow stream:
+
+$$
+\sum_{i=0}^n \frac{c_i}{(1+r)^i}=0
+$$
+
+This means the stream $(c_0,c_1,\ldots,c_n)$ is equivalent to the zero
+cash flow stream $(0,0,\ldots,0)$ at the chosen focal time.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The equation of value compares cash flow streams at the same focal time,
+usually time $0$.
+
+If two streams are equivalent at time $0$, then:
+
+$$
+\operatorname{PV}(C)=\operatorname{PV}(D)
+$$
+
+If one side is the zero cash flow stream, its present value is $0$, so the
+equation becomes a zero-sum present value equation.
+
+Each cash flow $c_i$ is discounted to time $0$:
+
+$$
+\frac{c_i}{(1+r)^i}
+$$
+
+Adding all discounted cash flows gives:
+
+$$
+\sum_{i=0}^n \frac{c_i}{(1+r)^i}
+$$
+
+Setting the sum equal to $0$ means the stream exactly balances the zero
+cash flow stream at the chosen rate $r$.
+
+</details>
+
+## Internal Rate of Return
+
+Any non-negative root $r$ of the equation of value is called the yield or
+effective internal rate of return, abbreviated $\operatorname{IRR}$.
+
+$$
+\sum_{i=0}^n \frac{c_i}{(1+r)^i} = 0
+$$
+
+Remarks:
+
+- IRR is determined entirely by the cash flows, not by a prevailing market interest rate.
+- If the IRR is unique, it is the rate of return on the investment.
+- A cash flow can have multiple IRRs or no non-negative IRR.
+
+Using $x = 1/(1+r)$, the equation of value becomes a polynomial:
+
+$$
+c_0 + c_1x + c_2x^2 + \cdots + c_nx^n = 0
+$$
+
+This polynomial has at most $n$ distinct roots.
+
+Decision rule when IRR is unique:
+
+$$
+\text{Invest if IRR} > \text{required return.}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+IRR is the rate that makes the net present value equal to zero.
+
+Using:
+
+$$
+x=\frac{1}{1+r}
+$$
+
+we have:
+
+$$
+\frac{1}{(1+r)^i}=x^i
+$$
+
+So:
+
+$$
+\sum_{i=0}^n \frac{c_i}{(1+r)^i}=0
+$$
+
+becomes:
+
+$$
+c_0+c_1x+c_2x^2+\cdots+c_nx^n=0
+$$
+
+This is a polynomial of degree at most $n$, so it has at most $n$ distinct
+real roots. This is why cash flows may have more than one IRR.
+
+</details>
+
+## Uniqueness of IRR
+
+The IRR is guaranteed to be unique if the cash flow stream
+$(c_0,c_1,\ldots,c_n)$ satisfies:
+
+$$
+c_0 < 0
+$$
+
+$$
+c_k \ge 0 \quad \text{for all } k = 1,\ldots,n
+$$
+
+$$
+c_0 + c_1 + \cdots + c_n > 0
+$$
+
+Intuition: there is one initial investment outflow, followed only by
+non-negative inflows, and the total cash flow is positive.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Let:
+
+$$
+f(r)=\sum_{i=0}^n \frac{c_i}{(1+r)^i}
+$$
+
+At $r=0$:
+
+$$
+f(0)=c_0+c_1+\cdots+c_n>0
+$$
+
+As $r$ becomes very large, the future cash flows are heavily discounted,
+so:
+
+$$
+f(r)\to c_0<0
+$$
+
+Since $f(r)$ moves from positive to negative, at least one root exists.
+
+Also, under the stated cash flow pattern, as $r$ increases, the present
+value of the non-negative future inflows decreases while $c_0$ stays
+fixed. Therefore $f(r)$ crosses zero only once.
+
+So the IRR is unique.
+
+</details>
+
+## Newton-Raphson Method
+
+For a general cash flow stream with $n \ge 5$, there is no general formula
+for IRR. Numerical methods may be used instead.
+
+Newton-Raphson is used to approximate a root of a differentiable function
+$f(z)$.
+
+Start with an initial guess $\alpha_0$. Then iterate:
+
+$$
+\alpha_{k+1}
+= \alpha_k - \frac{f(\alpha_k)}{f'(\alpha_k)}
+$$
+
+provided:
+
+$$
+f'(\alpha_k) \ne 0
+$$
+
+For IRR, $f(r)$ is usually the present value equation:
+
+$$
+f(r) = \sum_{i=0}^n \frac{c_i}{(1+r)^i}
+$$
+
+Repeat until the desired accuracy is reached.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Newton-Raphson finds a root by repeatedly replacing a curve with its
+tangent line.
+
+At the current guess $\alpha_k$, the tangent line to $f$ is:
+
+$$
+y=f(\alpha_k)+f'(\alpha_k)(z-\alpha_k)
+$$
+
+The next guess $\alpha_{k+1}$ is where this tangent line crosses the
+$z$-axis. Set $y=0$:
+
+$$
+0=f(\alpha_k)+f'(\alpha_k)(\alpha_{k+1}-\alpha_k)
+$$
+
+Solving for $\alpha_{k+1}$:
+
+$$
+\alpha_{k+1}
+=\alpha_k-\frac{f(\alpha_k)}{f'(\alpha_k)}
+$$
+
+</details>
+
+## Annuity
+
+An annuity is a series of equal payments made at regular intervals.
+
+Notation:
+
+$$
+A = \text{payment per period}, \qquad
+r = \text{effective interest rate per period}, \qquad
+n = \text{number of payments}.
+$$
+
+An annuity can be viewed as a cash flow stream:
+
+$$
+\{(A,t_1),(A,t_2),\ldots,(A,t_n)\}
+$$
+
+where the payments occur at equally spaced times.
+
+## Ordinary Annuity vs Annuity Due
+
+An ordinary annuity has payments at the end of each period:
+
+$$
+t = 1,2,\ldots,n
+$$
+
+Its present value at $t = 0$ is:
+
+$$
+\operatorname{PV}
+= \sum_{j=1}^n \frac{A}{(1+r)^j}
+= \frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
+$$
+
+An annuity due has payments at the beginning of each period:
+
+$$
+t = 0,1,\ldots,n-1
+$$
+
+Its present value at $t = 0$ is:
+
+$$
+\operatorname{PV}
+= \sum_{j=0}^{n-1} \frac{A}{(1+r)^j}
+= \frac{A(1+r)}{r}\left[1-\frac{1}{(1+r)^n}\right]
+$$
+
+Relationship:
+
+$$
+\operatorname{PV}(\text{annuity due})
+= (1+r)\operatorname{PV}(\text{ordinary annuity})
+$$
+
+The time value of an annuity can be obtained from:
+
+$$
+\operatorname{TV}_t = \operatorname{PV}(1+r)^t
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+For an ordinary annuity, payments occur at times:
+
+$$
+1,2,\ldots,n
+$$
+
+So the present value is:
+
+$$
+\operatorname{PV}
+=A\left[
+\frac{1}{1+r}
++\frac{1}{(1+r)^2}
++\cdots
++\frac{1}{(1+r)^n}
+\right]
+$$
+
+This is a finite geometric series with first term $\frac{1}{1+r}$ and
+common ratio $\frac{1}{1+r}$, so:
+
+$$
+\operatorname{PV}
+=\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
+$$
+
+For an annuity due, every payment occurs one period earlier than in an
+ordinary annuity. Therefore its present value is one period of
+accumulation larger:
+
+$$
+\operatorname{PV}(\text{annuity due})
+=(1+r)\operatorname{PV}(\text{ordinary annuity})
+$$
+
+</details>
+
+## Perpetual Annuity
+
+A perpetual annuity, or perpetuity, pays a fixed amount forever.
+
+For payments at the beginning of each period:
+
+$$
+\operatorname{PV}
+= \sum_{j=0}^{\infty} \frac{A}{(1+r)^j}
+= \frac{A(1+r)}{r}
+$$
+
+For payments at the end of each period:
+
+$$
+\operatorname{PV}
+= \sum_{j=1}^{\infty} \frac{A}{(1+r)^j}
+= \frac{A}{r}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A perpetuity is an annuity with infinitely many payments.
+
+For end-of-period payments:
+
+$$
+\operatorname{PV}
+=A\left[
+\frac{1}{1+r}
++\frac{1}{(1+r)^2}
++\cdots
+\right]
+$$
+
+This is an infinite geometric series with first term $\frac{1}{1+r}$ and
+common ratio $\frac{1}{1+r}$, so:
+
+$$
+\operatorname{PV}=\frac{A}{r}
+$$
+
+For beginning-of-period payments, the first payment occurs immediately at
+time $0$. This makes the value one period larger:
+
+$$
+\operatorname{PV}=\frac{A(1+r)}{r}
+$$
+
+</details>
+
+## Loans
+
+Loans are usually repaid by installment payments at regular intervals. If
+$L$ is the loan amount at $t = 0$ and $C$ is the repayment stream:
+
+$$
+L = \operatorname{PV}(C)
+$$
+
+For equal end-of-period payments $A$ over $n$ periods:
+
+$$
+L = \frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
+$$
+
+So:
+
+$$
+A = \frac{Lr}{1-\frac{1}{(1+r)^n}}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+At the start of the loan, the loan amount must equal the present value of
+all repayments:
+
+$$
+L=\operatorname{PV}(C)
+$$
+
+For equal end-of-period repayments, the repayment stream is an ordinary
+annuity. Therefore:
+
+$$
+L=\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
+$$
+
+Solving for $A$ gives:
+
+$$
+A=\frac{Lr}{1-\frac{1}{(1+r)^n}}
+$$
+
+</details>
+
+## Loan Balance: Prospective vs Retrospective
+
+Let:
+
+$$
+\begin{aligned}
+L &= \text{original loan amount}, \\
+A &= \text{installment payment per period}, \\
+r &= \text{effective interest rate per period}, \\
+n &= \text{total number of payments}, \\
+m &= \text{number of payments already made}, \\
+L_m^{\text{Bal}} &= \text{loan balance immediately after the } m\text{th payment}.
+\end{aligned}
+$$
+
+### Prospective Method
+
+This looks forward. The loan balance is the present value at time $m$ of
+the remaining $n-m$ payments.
+
+$$
+L_m^{\text{Bal}}
+= \frac{A}{1+r}
++ \frac{A}{(1+r)^2}
++ \cdots
++ \frac{A}{(1+r)^{n-m}}
+$$
+
+Using the annuity formula:
+
+$$
+L_m^{\text{Bal}}
+= \frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]
+$$
+
+This method does not require the original loan amount $L$.
+
+### Retrospective Method
+
+This looks backward. Accumulate the original loan to time $m$, then
+subtract the accumulated value of the payments already made.
+
+$$
+L_m^{\text{Bal}}
+= L(1+r)^m - \frac{A}{r}\left[(1+r)^m - 1\right]
+$$
+
+Equivalently, as written using the ordinary annuity PV factor accumulated
+to time $m$:
+
+$$
+L_m^{\text{Bal}}
+= L(1+r)^m
+- \frac{A}{r}\left[1-\frac{1}{(1+r)^m}\right](1+r)^m
+$$
+
+This method requires the original loan amount $L$.
+
+Both methods give the same balance.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The prospective method looks forward from time $m$. Immediately after the
+$m$th payment, there are $n-m$ payments left. The balance is the present
+value at time $m$ of those remaining payments:
+
+$$
+L_m^{\text{Bal}}
+=\frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]
+$$
+
+The retrospective method looks backward. Start with the original loan and
+accumulate it to time $m$:
+
+$$
+L(1+r)^m
+$$
+
+Then subtract the accumulated value at time $m$ of the $m$ payments
+already made:
+
+$$
+A\frac{(1+r)^m-1}{r}
+$$
+
+Therefore:
+
+$$
+L_m^{\text{Bal}}
+=L(1+r)^m-\frac{A}{r}\left[(1+r)^m-1\right]
+$$
+
+Both methods give the same result because they are just two different
+ways to value the same remaining loan obligation.
+
+</details>
+
+## Key Takeaways
+
+- Present value discounts future cash flows back to today.
+- Time value moves a cash flow's value to another time.
+- NPV includes both negative and positive cash flows.
+- IRR is a non-negative rate that makes $\operatorname{NPV} = 0$.
+- IRR is unique under the standard pattern: one initial outflow, then non-negative inflows, with positive total cash flow.
+- Newton-Raphson approximates roots using $\alpha_{k+1} = \alpha_k - f(\alpha_k)/f'(\alpha_k)$.
+- Ordinary annuity pays at period ends; annuity due pays at period beginnings.
+- Perpetuity pays forever.
+- Prospective loan balance looks at future payments; retrospective loan balance looks at the accumulated loan minus accumulated past payments.

--- a/NUS/QF1100/summary/Lecture 02.md
+++ b/NUS/QF1100/summary/Lecture 02.md
@@ -164,24 +164,24 @@ Finding the present value of a future payment is called discounting.
 If one unit at time $0$ grows to $a(t)$ units at time $t$, then the amount
 at time $0$ that grows to $c$ at time $t$ must be:
 
-$\displaystyle \frac{c}{a(t)}$
+$\frac{c}{a(t)}$
 
 because:
 
-$\displaystyle \frac{c}{a(t)}a(t)=c$
+$\frac{c}{a(t)}a(t)=c$
 
 When the effective interest rate is constant:
 
-$\displaystyle a(t)=(1+r)^t$
+$a(t)=(1+r)^t$
 
 so:
 
-$\displaystyle \operatorname{PV}=\frac{c}{(1+r)^t}$
+$\mathrm{PV}=\frac{c}{(1+r)^t}$
 
 For a stream of cash flows, present value is additive. Each cash flow is
 discounted to time $0$, then added:
 
-$\displaystyle \operatorname{PV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}$
+$\mathrm{PV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}$
 
 </details>
 
@@ -220,24 +220,24 @@ $$
 The present value of $C$ is its value at time $0$. To move that value to
 time $t$, accumulate it by $a(t)$:
 
-$\displaystyle \operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)$
+$\mathrm{TV}_t(C)=\mathrm{PV}(C)a(t)$
 
 To move from time $s$ to time $t$, multiply by the accumulation factor
 from $s$ to $t$:
 
-$\displaystyle a(s,t)=\frac{a(t)}{a(s)}$
+$a(s,t)=\frac{a(t)}{a(s)}$
 
 So:
 
-$\displaystyle \operatorname{TV}_t(C) =\frac{a(t)}{a(s)}\operatorname{TV}_s(C)$
+$\mathrm{TV}_t(C) =\frac{a(t)}{a(s)}\mathrm{TV}_s(C)$
 
 When $a(t)=(1+r)^t$:
 
-$\displaystyle \frac{a(t)}{a(s)} =\frac{(1+r)^t}{(1+r)^s} =(1+r)^{t-s}$
+$\frac{a(t)}{a(s)} =\frac{(1+r)^t}{(1+r)^s} =(1+r)^{t-s}$
 
 For each cash flow $c_i$ at time $t_i$, its value at time $t$ is:
 
-$\displaystyle \frac{c_i}{(1+r)^{t_i-t}}$
+$\frac{c_i}{(1+r)^{t_i-t}}$
 
 If $t_i>t$, this discounts backward. If $t_i<t$, the exponent is negative,
 so the expression accumulates forward.
@@ -258,15 +258,15 @@ $t$.
 
 If two cash flow streams $C$ and $D$ have the same present value, say:
 
-$\displaystyle \operatorname{PV}(C)=\operatorname{PV}(D)$
+$\mathrm{PV}(C)=\mathrm{PV}(D)$
 
 then their time values at time $t$ are:
 
-$\displaystyle \operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)$
+$\mathrm{TV}_t(C)=\mathrm{PV}(C)a(t)$
 
 and:
 
-$\displaystyle \operatorname{TV}_t(D)=\operatorname{PV}(D)a(t)$
+$\mathrm{TV}_t(D)=\mathrm{PV}(D)a(t)$
 
 Since the present values are equal, the time values are also equal.
 
@@ -312,9 +312,9 @@ NPV is just present value applied to signed cash flows.
 Positive cash flows are benefits and negative cash flows are costs.
 Discount every cash flow to time $0$, then add:
 
-$\displaystyle \operatorname{NPV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}$
+$\mathrm{NPV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}$
 
-If $\operatorname{NPV}>0$, the benefits are worth more today than the
+If $\mathrm{NPV}>0$, the benefits are worth more today than the
 costs, using the chosen discount rate.
 
 </details>
@@ -349,18 +349,18 @@ usually time $0$.
 
 If two streams are equivalent at time $0$, then:
 
-$\displaystyle \operatorname{PV}(C)=\operatorname{PV}(D)$
+$\mathrm{PV}(C)=\mathrm{PV}(D)$
 
 If one side is the zero cash flow stream, its present value is $0$, so the
 equation becomes a zero-sum present value equation.
 
 Each cash flow $c_i$ is discounted to time $0$:
 
-$\displaystyle \frac{c_i}{(1+r)^i}$
+$\frac{c_i}{(1+r)^i}$
 
 Adding all discounted cash flows gives:
 
-$\displaystyle \sum_{i=0}^n \frac{c_i}{(1+r)^i}$
+$\sum_{i=0}^n \frac{c_i}{(1+r)^i}$
 
 Setting the sum equal to $0$ means the stream exactly balances the zero
 cash flow stream at the chosen rate $r$.
@@ -403,19 +403,19 @@ IRR is the rate that makes the net present value equal to zero.
 
 Using:
 
-$\displaystyle x=\frac{1}{1+r}$
+$x=\frac{1}{1+r}$
 
 we have:
 
-$\displaystyle \frac{1}{(1+r)^i}=x^i$
+$\frac{1}{(1+r)^i}=x^i$
 
 So:
 
-$\displaystyle \sum_{i=0}^n \frac{c_i}{(1+r)^i}=0$
+$\sum_{i=0}^n \frac{c_i}{(1+r)^i}=0$
 
 becomes:
 
-$\displaystyle c_0+c_1x+c_2x^2+\cdots+c_nx^n=0$
+$c_0+c_1x+c_2x^2+\cdots+c_nx^n=0$
 
 This is a polynomial of degree at most $n$, so it has at most $n$ distinct
 real roots. This is why cash flows may have more than one IRR.
@@ -447,16 +447,16 @@ non-negative inflows, and the total cash flow is positive.
 
 Let:
 
-$\displaystyle f(r)=\sum_{i=0}^n \frac{c_i}{(1+r)^i}$
+$f(r)=\sum_{i=0}^n \frac{c_i}{(1+r)^i}$
 
 At $r=0$:
 
-$\displaystyle f(0)=c_0+c_1+\cdots+c_n>0$
+$f(0)=c_0+c_1+\cdots+c_n>0$
 
 As $r$ becomes very large, the future cash flows are heavily discounted,
 so:
 
-$\displaystyle f(r)\to c_0<0$
+$f(r)\to c_0<0$
 
 Since $f(r)$ moves from positive to negative, at least one root exists.
 
@@ -505,16 +505,16 @@ tangent line.
 
 At the current guess $\alpha_k$, the tangent line to $f$ is:
 
-$\displaystyle y=f(\alpha_k)+f'(\alpha_k)(z-\alpha_k)$
+$y=f(\alpha_k)+f'(\alpha_k)(z-\alpha_k)$
 
 The next guess $\alpha_{k+1}$ is where this tangent line crosses the
 $z$-axis. Set $y=0$:
 
-$\displaystyle 0=f(\alpha_k)+f'(\alpha_k)(\alpha_{k+1}-\alpha_k)$
+$0=f(\alpha_k)+f'(\alpha_k)(\alpha_{k+1}-\alpha_k)$
 
 Solving for $\alpha_{k+1}$:
 
-$\displaystyle \alpha_{k+1} =\alpha_k-\frac{f(\alpha_k)}{f'(\alpha_k)}$
+$\alpha_{k+1} =\alpha_k-\frac{f(\alpha_k)}{f'(\alpha_k)}$
 
 </details>
 
@@ -586,22 +586,23 @@ $$
 
 For an ordinary annuity, payments occur at times:
 
-$\displaystyle 1,2,\ldots,n$
+$1,2,\ldots,n$
 
 So the present value is:
 
-$\displaystyle \operatorname{PV} =A\left[ \frac{1}{1+r} +\frac{1}{(1+r)^2} +\cdots +\frac{1}{(1+r)^n} \right]$
+$\mathrm{PV} =A[ \frac{1}{1+r} +\frac{1}{(1+r)^2} +\cdots +\frac{1}{(1+r)^n} ]$
 
 This is a finite geometric series with first term $\frac{1}{1+r}$ and
 common ratio $\frac{1}{1+r}$, so:
 
-$\displaystyle \operatorname{PV} =\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]$
+$\mathrm{PV} =\frac{A}{r}[1-\frac{1}{(1+r)^n}]$
 
 For an annuity due, every payment occurs one period earlier than in an
 ordinary annuity. Therefore its present value is one period of
 accumulation larger:
 
-$\displaystyle \operatorname{PV}(\text{annuity due}) =(1+r)\operatorname{PV}(\text{ordinary annuity})$
+PV of an annuity due equals $(1+r)$ times the PV of the corresponding
+ordinary annuity.
 
 </details>
 
@@ -632,17 +633,17 @@ A perpetuity is an annuity with infinitely many payments.
 
 For end-of-period payments:
 
-$\displaystyle \operatorname{PV} =A\left[ \frac{1}{1+r} +\frac{1}{(1+r)^2} +\cdots \right]$
+$\mathrm{PV} =A[ \frac{1}{1+r} +\frac{1}{(1+r)^2} +\cdots ]$
 
 This is an infinite geometric series with first term $\frac{1}{1+r}$ and
 common ratio $\frac{1}{1+r}$, so:
 
-$\displaystyle \operatorname{PV}=\frac{A}{r}$
+$\mathrm{PV}=\frac{A}{r}$
 
 For beginning-of-period payments, the first payment occurs immediately at
 time $0$. This makes the value one period larger:
 
-$\displaystyle \operatorname{PV}=\frac{A(1+r)}{r}$
+$\mathrm{PV}=\frac{A(1+r)}{r}$
 
 </details>
 
@@ -673,16 +674,16 @@ $$
 At the start of the loan, the loan amount must equal the present value of
 all repayments:
 
-$\displaystyle L=\operatorname{PV}(C)$
+$L=\mathrm{PV}(C)$
 
 For equal end-of-period repayments, the repayment stream is an ordinary
 annuity. Therefore:
 
-$\displaystyle L=\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]$
+$L=\frac{A}{r}[1-\frac{1}{(1+r)^n}]$
 
 Solving for $A$ gives:
 
-$\displaystyle A=\frac{Lr}{1-\frac{1}{(1+r)^n}}$
+$A=\frac{Lr}{1-\frac{1}{(1+r)^n}}$
 
 </details>
 
@@ -753,21 +754,21 @@ The prospective method looks forward from time $m$. Immediately after the
 $m$th payment, there are $n-m$ payments left. The balance is the present
 value at time $m$ of those remaining payments:
 
-$\displaystyle L_m^{\text{Bal}} =\frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]$
+$L_m^{\mathrm{Bal}} = \frac{A}{r}[1-\frac{1}{(1+r)^{n-m}}]$
 
 The retrospective method looks backward. Start with the original loan and
 accumulate it to time $m$:
 
-$\displaystyle L(1+r)^m$
+$L(1+r)^m$
 
 Then subtract the accumulated value at time $m$ of the $m$ payments
 already made:
 
-$\displaystyle A\frac{(1+r)^m-1}{r}$
+$A\frac{(1+r)^m-1}{r}$
 
 Therefore:
 
-$\displaystyle L_m^{\text{Bal}} =L(1+r)^m-\frac{A}{r}\left[(1+r)^m-1\right]$
+$L_m^{\mathrm{Bal}} = L(1+r)^m-\frac{A}{r}[(1+r)^m-1]$
 
 Both methods give the same result because they are just two different
 ways to value the same remaining loan obligation.

--- a/NUS/QF1100/summary/Lecture 02.md
+++ b/NUS/QF1100/summary/Lecture 02.md
@@ -164,34 +164,24 @@ Finding the present value of a future payment is called discounting.
 If one unit at time $0$ grows to $a(t)$ units at time $t$, then the amount
 at time $0$ that grows to $c$ at time $t$ must be:
 
-$$
-\frac{c}{a(t)}
-$$
+$\displaystyle \frac{c}{a(t)}$
 
 because:
 
-$$
-\frac{c}{a(t)}a(t)=c
-$$
+$\displaystyle \frac{c}{a(t)}a(t)=c$
 
 When the effective interest rate is constant:
 
-$$
-a(t)=(1+r)^t
-$$
+$\displaystyle a(t)=(1+r)^t$
 
 so:
 
-$$
-\operatorname{PV}=\frac{c}{(1+r)^t}
-$$
+$\displaystyle \operatorname{PV}=\frac{c}{(1+r)^t}$
 
 For a stream of cash flows, present value is additive. Each cash flow is
 discounted to time $0$, then added:
 
-$$
-\operatorname{PV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}
-$$
+$\displaystyle \operatorname{PV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}$
 
 </details>
 
@@ -230,37 +220,24 @@ $$
 The present value of $C$ is its value at time $0$. To move that value to
 time $t$, accumulate it by $a(t)$:
 
-$$
-\operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)
-$$
+$\displaystyle \operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)$
 
 To move from time $s$ to time $t$, multiply by the accumulation factor
 from $s$ to $t$:
 
-$$
-a(s,t)=\frac{a(t)}{a(s)}
-$$
+$\displaystyle a(s,t)=\frac{a(t)}{a(s)}$
 
 So:
 
-$$
-\operatorname{TV}_t(C)
-=\frac{a(t)}{a(s)}\operatorname{TV}_s(C)
-$$
+$\displaystyle \operatorname{TV}_t(C) =\frac{a(t)}{a(s)}\operatorname{TV}_s(C)$
 
 When $a(t)=(1+r)^t$:
 
-$$
-\frac{a(t)}{a(s)}
-=\frac{(1+r)^t}{(1+r)^s}
-=(1+r)^{t-s}
-$$
+$\displaystyle \frac{a(t)}{a(s)} =\frac{(1+r)^t}{(1+r)^s} =(1+r)^{t-s}$
 
 For each cash flow $c_i$ at time $t_i$, its value at time $t$ is:
 
-$$
-\frac{c_i}{(1+r)^{t_i-t}}
-$$
+$\displaystyle \frac{c_i}{(1+r)^{t_i-t}}$
 
 If $t_i>t$, this discounts backward. If $t_i<t$, the exponent is negative,
 so the expression accumulates forward.
@@ -281,21 +258,15 @@ $t$.
 
 If two cash flow streams $C$ and $D$ have the same present value, say:
 
-$$
-\operatorname{PV}(C)=\operatorname{PV}(D)
-$$
+$\displaystyle \operatorname{PV}(C)=\operatorname{PV}(D)$
 
 then their time values at time $t$ are:
 
-$$
-\operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)
-$$
+$\displaystyle \operatorname{TV}_t(C)=\operatorname{PV}(C)a(t)$
 
 and:
 
-$$
-\operatorname{TV}_t(D)=\operatorname{PV}(D)a(t)
-$$
+$\displaystyle \operatorname{TV}_t(D)=\operatorname{PV}(D)a(t)$
 
 Since the present values are equal, the time values are also equal.
 
@@ -341,9 +312,7 @@ NPV is just present value applied to signed cash flows.
 Positive cash flows are benefits and negative cash flows are costs.
 Discount every cash flow to time $0$, then add:
 
-$$
-\operatorname{NPV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}
-$$
+$\displaystyle \operatorname{NPV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}$
 
 If $\operatorname{NPV}>0$, the benefits are worth more today than the
 costs, using the chosen discount rate.
@@ -380,24 +349,18 @@ usually time $0$.
 
 If two streams are equivalent at time $0$, then:
 
-$$
-\operatorname{PV}(C)=\operatorname{PV}(D)
-$$
+$\displaystyle \operatorname{PV}(C)=\operatorname{PV}(D)$
 
 If one side is the zero cash flow stream, its present value is $0$, so the
 equation becomes a zero-sum present value equation.
 
 Each cash flow $c_i$ is discounted to time $0$:
 
-$$
-\frac{c_i}{(1+r)^i}
-$$
+$\displaystyle \frac{c_i}{(1+r)^i}$
 
 Adding all discounted cash flows gives:
 
-$$
-\sum_{i=0}^n \frac{c_i}{(1+r)^i}
-$$
+$\displaystyle \sum_{i=0}^n \frac{c_i}{(1+r)^i}$
 
 Setting the sum equal to $0$ means the stream exactly balances the zero
 cash flow stream at the chosen rate $r$.
@@ -440,27 +403,19 @@ IRR is the rate that makes the net present value equal to zero.
 
 Using:
 
-$$
-x=\frac{1}{1+r}
-$$
+$\displaystyle x=\frac{1}{1+r}$
 
 we have:
 
-$$
-\frac{1}{(1+r)^i}=x^i
-$$
+$\displaystyle \frac{1}{(1+r)^i}=x^i$
 
 So:
 
-$$
-\sum_{i=0}^n \frac{c_i}{(1+r)^i}=0
-$$
+$\displaystyle \sum_{i=0}^n \frac{c_i}{(1+r)^i}=0$
 
 becomes:
 
-$$
-c_0+c_1x+c_2x^2+\cdots+c_nx^n=0
-$$
+$\displaystyle c_0+c_1x+c_2x^2+\cdots+c_nx^n=0$
 
 This is a polynomial of degree at most $n$, so it has at most $n$ distinct
 real roots. This is why cash flows may have more than one IRR.
@@ -492,22 +447,16 @@ non-negative inflows, and the total cash flow is positive.
 
 Let:
 
-$$
-f(r)=\sum_{i=0}^n \frac{c_i}{(1+r)^i}
-$$
+$\displaystyle f(r)=\sum_{i=0}^n \frac{c_i}{(1+r)^i}$
 
 At $r=0$:
 
-$$
-f(0)=c_0+c_1+\cdots+c_n>0
-$$
+$\displaystyle f(0)=c_0+c_1+\cdots+c_n>0$
 
 As $r$ becomes very large, the future cash flows are heavily discounted,
 so:
 
-$$
-f(r)\to c_0<0
-$$
+$\displaystyle f(r)\to c_0<0$
 
 Since $f(r)$ moves from positive to negative, at least one root exists.
 
@@ -556,23 +505,16 @@ tangent line.
 
 At the current guess $\alpha_k$, the tangent line to $f$ is:
 
-$$
-y=f(\alpha_k)+f'(\alpha_k)(z-\alpha_k)
-$$
+$\displaystyle y=f(\alpha_k)+f'(\alpha_k)(z-\alpha_k)$
 
 The next guess $\alpha_{k+1}$ is where this tangent line crosses the
 $z$-axis. Set $y=0$:
 
-$$
-0=f(\alpha_k)+f'(\alpha_k)(\alpha_{k+1}-\alpha_k)
-$$
+$\displaystyle 0=f(\alpha_k)+f'(\alpha_k)(\alpha_{k+1}-\alpha_k)$
 
 Solving for $\alpha_{k+1}$:
 
-$$
-\alpha_{k+1}
-=\alpha_k-\frac{f(\alpha_k)}{f'(\alpha_k)}
-$$
+$\displaystyle \alpha_{k+1} =\alpha_k-\frac{f(\alpha_k)}{f'(\alpha_k)}$
 
 </details>
 
@@ -644,38 +586,22 @@ $$
 
 For an ordinary annuity, payments occur at times:
 
-$$
-1,2,\ldots,n
-$$
+$\displaystyle 1,2,\ldots,n$
 
 So the present value is:
 
-$$
-\operatorname{PV}
-=A\left[
-\frac{1}{1+r}
-+\frac{1}{(1+r)^2}
-+\cdots
-+\frac{1}{(1+r)^n}
-\right]
-$$
+$\displaystyle \operatorname{PV} =A\left[ \frac{1}{1+r} +\frac{1}{(1+r)^2} +\cdots +\frac{1}{(1+r)^n} \right]$
 
 This is a finite geometric series with first term $\frac{1}{1+r}$ and
 common ratio $\frac{1}{1+r}$, so:
 
-$$
-\operatorname{PV}
-=\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
-$$
+$\displaystyle \operatorname{PV} =\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]$
 
 For an annuity due, every payment occurs one period earlier than in an
 ordinary annuity. Therefore its present value is one period of
 accumulation larger:
 
-$$
-\operatorname{PV}(\text{annuity due})
-=(1+r)\operatorname{PV}(\text{ordinary annuity})
-$$
+$\displaystyle \operatorname{PV}(\text{annuity due}) =(1+r)\operatorname{PV}(\text{ordinary annuity})$
 
 </details>
 
@@ -706,28 +632,17 @@ A perpetuity is an annuity with infinitely many payments.
 
 For end-of-period payments:
 
-$$
-\operatorname{PV}
-=A\left[
-\frac{1}{1+r}
-+\frac{1}{(1+r)^2}
-+\cdots
-\right]
-$$
+$\displaystyle \operatorname{PV} =A\left[ \frac{1}{1+r} +\frac{1}{(1+r)^2} +\cdots \right]$
 
 This is an infinite geometric series with first term $\frac{1}{1+r}$ and
 common ratio $\frac{1}{1+r}$, so:
 
-$$
-\operatorname{PV}=\frac{A}{r}
-$$
+$\displaystyle \operatorname{PV}=\frac{A}{r}$
 
 For beginning-of-period payments, the first payment occurs immediately at
 time $0$. This makes the value one period larger:
 
-$$
-\operatorname{PV}=\frac{A(1+r)}{r}
-$$
+$\displaystyle \operatorname{PV}=\frac{A(1+r)}{r}$
 
 </details>
 
@@ -758,22 +673,16 @@ $$
 At the start of the loan, the loan amount must equal the present value of
 all repayments:
 
-$$
-L=\operatorname{PV}(C)
-$$
+$\displaystyle L=\operatorname{PV}(C)$
 
 For equal end-of-period repayments, the repayment stream is an ordinary
 annuity. Therefore:
 
-$$
-L=\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
-$$
+$\displaystyle L=\frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]$
 
 Solving for $A$ gives:
 
-$$
-A=\frac{Lr}{1-\frac{1}{(1+r)^n}}
-$$
+$\displaystyle A=\frac{Lr}{1-\frac{1}{(1+r)^n}}$
 
 </details>
 
@@ -844,31 +753,21 @@ The prospective method looks forward from time $m$. Immediately after the
 $m$th payment, there are $n-m$ payments left. The balance is the present
 value at time $m$ of those remaining payments:
 
-$$
-L_m^{\text{Bal}}
-=\frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]
-$$
+$\displaystyle L_m^{\text{Bal}} =\frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]$
 
 The retrospective method looks backward. Start with the original loan and
 accumulate it to time $m$:
 
-$$
-L(1+r)^m
-$$
+$\displaystyle L(1+r)^m$
 
 Then subtract the accumulated value at time $m$ of the $m$ payments
 already made:
 
-$$
-A\frac{(1+r)^m-1}{r}
-$$
+$\displaystyle A\frac{(1+r)^m-1}{r}$
 
 Therefore:
 
-$$
-L_m^{\text{Bal}}
-=L(1+r)^m-\frac{A}{r}\left[(1+r)^m-1\right]
-$$
+$\displaystyle L_m^{\text{Bal}} =L(1+r)^m-\frac{A}{r}\left[(1+r)^m-1\right]$
 
 Both methods give the same result because they are just two different
 ways to value the same remaining loan obligation.

--- a/NUS/QF1100/summary/Lecture 02.md
+++ b/NUS/QF1100/summary/Lecture 02.md
@@ -56,11 +56,11 @@ j = \text{index used in annuity or perpetuity payment sums}
 $$
 
 $$
-\operatorname{PV}(C) = \text{present value of cash flow stream } C
+\mathrm{PV}(C) = \text{present value of cash flow stream } C
 $$
 
 $$
-\operatorname{TV}_t(C) = \text{time value of } C \text{ at time } t
+\mathrm{TV}_t(C) = \text{time value of } C \text{ at time } t
 $$
 
 $$
@@ -68,7 +68,7 @@ s = \text{another time point used when moving values between times}
 $$
 
 $$
-\operatorname{NPV}(C) = \text{net present value of cash flow stream } C
+\mathrm{NPV}(C) = \text{net present value of cash flow stream } C
 $$
 
 $$
@@ -80,7 +80,7 @@ x = \frac{1}{1+r}
 $$
 
 $$
-\operatorname{IRR} = \text{internal rate of return}
+\mathrm{IRR} = \text{internal rate of return}
 $$
 
 $$
@@ -129,13 +129,13 @@ Present value asks: how much is a future payment worth today?
 For a single payment $c$ at time $t \ge 0$:
 
 $$
-\operatorname{PV} = \frac{c}{a(t)}
+\mathrm{PV} = \frac{c}{a(t)}
 $$
 
 If the effective interest rate is $r$:
 
 $$
-\operatorname{PV} = \frac{c}{(1+r)^t}
+\mathrm{PV} = \frac{c}{(1+r)^t}
 $$
 
 For a cash flow stream
@@ -147,13 +147,13 @@ $$
 the present value is:
 
 $$
-\operatorname{PV}(C) = \sum_{i=1}^n \frac{c_i}{a(t_i)}
+\mathrm{PV}(C) = \sum_{i=1}^n \frac{c_i}{a(t_i)}
 $$
 
 If the effective interest rate is $r$:
 
 $$
-\operatorname{PV}(C) = \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i}}
+\mathrm{PV}(C) = \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i}}
 $$
 
 Finding the present value of a future payment is called discounting.
@@ -187,31 +187,29 @@ $\mathrm{PV}(C)=\sum_{i=1}^n \frac{c_i}{a(t_i)}$
 
 ## Time Value
 
-The time value of cash flow $C$ at time $t$, denoted $\operatorname{TV}_t(C)$,
+The time value of cash flow $C$ at time $t$, denoted $\mathrm{TV}_t(C)$,
 is:
 
 $$
-\operatorname{TV}_t(C) = \operatorname{PV}(C)a(t)
+\mathrm{TV}_t(C) = \mathrm{PV}(C)a(t)
 $$
 
 For $0 < s < t$:
 
 $$
-\operatorname{TV}_t(C)
-= \frac{a(t)}{a(s)}\operatorname{TV}_s(C)
+\mathrm{TV}_t(C) = \frac{a(t)}{a(s)}\mathrm{TV}_s(C)
 $$
 
 If the effective interest rate is $r$:
 
 $$
-\operatorname{TV}_t(C)
-= \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i-t}}
+\mathrm{TV}_t(C) = \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i-t}}
 $$
 
 and:
 
 $$
-\operatorname{TV}_t(C) = \operatorname{TV}_s(C)(1+r)^{t-s}
+\mathrm{TV}_t(C) = \mathrm{TV}_s(C)(1+r)^{t-s}
 $$
 
 <details>
@@ -277,7 +275,7 @@ same accumulation method is used.
 
 ## Net Present Value
 
-Net present value, or $\operatorname{NPV}$, is the present value of all cash
+Net present value, or $\mathrm{NPV}$, is the present value of all cash
 flows in an investment project, including both negative and positive cash
 flows.
 
@@ -290,19 +288,19 @@ $$
 the net present value is:
 
 $$
-\operatorname{NPV}(C) = \sum_{i=1}^n \frac{c_i}{a(t_i)}
+\mathrm{NPV}(C) = \sum_{i=1}^n \frac{c_i}{a(t_i)}
 $$
 
 If the effective interest rate is $r$:
 
 $$
-\operatorname{NPV}(C) = \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i}}
+\mathrm{NPV}(C) = \sum_{i=1}^n \frac{c_i}{(1+r)^{t_i}}
 $$
 
 Decision rules:
 
-- Invest if $\operatorname{NPV} > 0$.
-- Project A is preferred to Project B if $\operatorname{NPV}(A) > \operatorname{NPV}(B)$.
+- Invest if $\mathrm{NPV} > 0$.
+- Project A is preferred to Project B if $\mathrm{NPV}(A) > \mathrm{NPV}(B)$.
 
 <details>
 <summary>Intuition / proof</summary>
@@ -327,7 +325,7 @@ same focal time and setting those values equal.
 At time $0$, if cash flow streams $C$ and $D$ are equivalent, then:
 
 $$
-\operatorname{PV}(C)=\operatorname{PV}(D)
+\mathrm{PV}(C)=\mathrm{PV}(D)
 $$
 
 For a cash flow stream written as $(c_0,c_1,\ldots,c_n)$ at integer
@@ -370,7 +368,7 @@ cash flow stream at the chosen rate $r$.
 ## Internal Rate of Return
 
 Any non-negative root $r$ of the equation of value is called the yield or
-effective internal rate of return, abbreviated $\operatorname{IRR}$.
+effective internal rate of return, abbreviated $\mathrm{IRR}$.
 
 $$
 \sum_{i=0}^n \frac{c_i}{(1+r)^i} = 0
@@ -479,8 +477,7 @@ $f(z)$.
 Start with an initial guess $\alpha_0$. Then iterate:
 
 $$
-\alpha_{k+1}
-= \alpha_k - \frac{f(\alpha_k)}{f'(\alpha_k)}
+\alpha_{k+1} = \alpha_k - \frac{f(\alpha_k)}{f'(\alpha_k)}
 $$
 
 provided:
@@ -525,9 +522,7 @@ An annuity is a series of equal payments made at regular intervals.
 Notation:
 
 $$
-A = \text{payment per period}, \qquad
-r = \text{effective interest rate per period}, \qquad
-n = \text{number of payments}.
+A = \text{payment per period}, \qquad r = \text{effective interest rate per period}, \qquad n = \text{number of payments}.
 $$
 
 An annuity can be viewed as a cash flow stream:
@@ -549,9 +544,7 @@ $$
 Its present value at $t = 0$ is:
 
 $$
-\operatorname{PV}
-= \sum_{j=1}^n \frac{A}{(1+r)^j}
-= \frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
+\mathrm{PV} = \sum_{j=1}^n \frac{A}{(1+r)^j} = \frac{A}{r}\left[1-\frac{1}{(1+r)^n}\right]
 $$
 
 An annuity due has payments at the beginning of each period:
@@ -563,22 +556,19 @@ $$
 Its present value at $t = 0$ is:
 
 $$
-\operatorname{PV}
-= \sum_{j=0}^{n-1} \frac{A}{(1+r)^j}
-= \frac{A(1+r)}{r}\left[1-\frac{1}{(1+r)^n}\right]
+\mathrm{PV} = \sum_{j=0}^{n-1} \frac{A}{(1+r)^j} = \frac{A(1+r)}{r}\left[1-\frac{1}{(1+r)^n}\right]
 $$
 
 Relationship:
 
 $$
-\operatorname{PV}(\text{annuity due})
-= (1+r)\operatorname{PV}(\text{ordinary annuity})
+\mathrm{PV}(\text{annuity due}) = (1+r)\mathrm{PV}(\text{ordinary annuity})
 $$
 
 The time value of an annuity can be obtained from:
 
 $$
-\operatorname{TV}_t = \operatorname{PV}(1+r)^t
+\mathrm{TV}_t = \mathrm{PV}(1+r)^t
 $$
 
 <details>
@@ -613,17 +603,13 @@ A perpetual annuity, or perpetuity, pays a fixed amount forever.
 For payments at the beginning of each period:
 
 $$
-\operatorname{PV}
-= \sum_{j=0}^{\infty} \frac{A}{(1+r)^j}
-= \frac{A(1+r)}{r}
+\mathrm{PV} = \sum_{j=0}^{\infty} \frac{A}{(1+r)^j} = \frac{A(1+r)}{r}
 $$
 
 For payments at the end of each period:
 
 $$
-\operatorname{PV}
-= \sum_{j=1}^{\infty} \frac{A}{(1+r)^j}
-= \frac{A}{r}
+\mathrm{PV} = \sum_{j=1}^{\infty} \frac{A}{(1+r)^j} = \frac{A}{r}
 $$
 
 <details>
@@ -653,7 +639,7 @@ Loans are usually repaid by installment payments at regular intervals. If
 $L$ is the loan amount at $t = 0$ and $C$ is the repayment stream:
 
 $$
-L = \operatorname{PV}(C)
+L = \mathrm{PV}(C)
 $$
 
 For equal end-of-period payments $A$ over $n$ periods:
@@ -692,14 +678,7 @@ $A=\frac{Lr}{1-\frac{1}{(1+r)^n}}$
 Let:
 
 $$
-\begin{aligned}
-L &= \text{original loan amount}, \\
-A &= \text{installment payment per period}, \\
-r &= \text{effective interest rate per period}, \\
-n &= \text{total number of payments}, \\
-m &= \text{number of payments already made}, \\
-L_m^{\text{Bal}} &= \text{loan balance immediately after the } m\text{th payment}.
-\end{aligned}
+\begin{aligned} L &= \text{original loan amount}, \\ A &= \text{installment payment per period}, \\ r &= \text{effective interest rate per period}, \\ n &= \text{total number of payments}, \\ m &= \text{number of payments already made}, \\ L_m^{\text{Bal}} &= \text{loan balance immediately after the } m\text{th payment}. \end{aligned}
 $$
 
 ### Prospective Method
@@ -708,18 +687,13 @@ This looks forward. The loan balance is the present value at time $m$ of
 the remaining $n-m$ payments.
 
 $$
-L_m^{\text{Bal}}
-= \frac{A}{1+r}
-+ \frac{A}{(1+r)^2}
-+ \cdots
-+ \frac{A}{(1+r)^{n-m}}
+L_m^{\text{Bal}} = \frac{A}{1+r} + \frac{A}{(1+r)^2} + \cdots + \frac{A}{(1+r)^{n-m}}
 $$
 
 Using the annuity formula:
 
 $$
-L_m^{\text{Bal}}
-= \frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]
+L_m^{\text{Bal}} = \frac{A}{r}\left[1-\frac{1}{(1+r)^{n-m}}\right]
 $$
 
 This method does not require the original loan amount $L$.
@@ -730,17 +704,14 @@ This looks backward. Accumulate the original loan to time $m$, then
 subtract the accumulated value of the payments already made.
 
 $$
-L_m^{\text{Bal}}
-= L(1+r)^m - \frac{A}{r}\left[(1+r)^m - 1\right]
+L_m^{\text{Bal}} = L(1+r)^m - \frac{A}{r}\left[(1+r)^m - 1\right]
 $$
 
 Equivalently, as written using the ordinary annuity PV factor accumulated
 to time $m$:
 
 $$
-L_m^{\text{Bal}}
-= L(1+r)^m
-- \frac{A}{r}\left[1-\frac{1}{(1+r)^m}\right](1+r)^m
+L_m^{\text{Bal}} = L(1+r)^m - \frac{A}{r}\left[1-\frac{1}{(1+r)^m}\right](1+r)^m
 $$
 
 This method requires the original loan amount $L$.
@@ -780,7 +751,7 @@ ways to value the same remaining loan obligation.
 - Present value discounts future cash flows back to today.
 - Time value moves a cash flow's value to another time.
 - NPV includes both negative and positive cash flows.
-- IRR is a non-negative rate that makes $\operatorname{NPV} = 0$.
+- IRR is a non-negative rate that makes $\mathrm{NPV} = 0$.
 - IRR is unique under the standard pattern: one initial outflow, then non-negative inflows, with positive total cash flow.
 - Newton-Raphson approximates roots using $\alpha_{k+1} = \alpha_k - f(\alpha_k)/f'(\alpha_k)$.
 - Ordinary annuity pays at period ends; annuity due pays at period beginnings.

--- a/NUS/QF1100/summary/Lecture 03.md
+++ b/NUS/QF1100/summary/Lecture 03.md
@@ -1,0 +1,803 @@
+# Lecture 03
+
+This lecture explains how bonds are priced from their future cash flows
+and how duration summarizes the timing of those cash flows.
+
+Unless stated otherwise, time is measured in years, while payment indices
+count coupon periods.
+
+## Variable Definitions
+
+$$
+P = \text{current price of the bond}
+$$
+
+$$
+F = \text{face value, or par value, of the bond}
+$$
+
+$$
+R = \text{redemption value, or maturity value, paid at maturity}
+$$
+
+$$
+c = \text{nominal annual coupon rate}
+$$
+
+$$
+m = \text{number of coupon payments per year}
+$$
+
+$$
+N = \text{term of the bond in years}
+$$
+
+$$
+n = \text{total number of payment or discounting periods to maturity}
+$$
+
+$$
+\lambda = \text{nominal annual bond yield}
+$$
+
+$$
+\frac{\lambda}{m} = \text{yield per coupon period}
+$$
+
+$$
+\frac{cF}{m} = \text{coupon payment made each coupon period}
+$$
+
+$$
+i = \text{payment index}
+$$
+
+$$
+i/m = \text{time in years of the } i\text{th coupon payment}
+$$
+
+$$
+k = \text{number of coupon payments already made}
+$$
+
+$$
+P_k = \text{bond price immediately after the } k\text{th coupon payment}
+$$
+
+$$
+K = \text{present value of the face value in the Makeham formula}
+$$
+
+$$
+C = \text{general cash flow stream}
+$$
+
+$$
+\operatorname{PV}(C) = \text{present value of cash flow stream } C
+$$
+
+$$
+\operatorname{PV}(\{(c_i,t_i)\}) = \text{present value of the single cash flow } c_i \text{ at time } t_i
+$$
+
+$$
+r = \text{generic per-period discount rate used in annuity notation}
+$$
+
+$$
+a_{\overline{n}|\,r} = \text{present value of an ordinary annuity of } 1 \text{ per period for } n \text{ periods at rate } r
+$$
+
+$$
+c_i = \text{amount of the } i\text{th cash flow}
+$$
+
+$$
+t_i = \text{time of the } i\text{th cash flow}
+$$
+
+$$
+q = \text{number of cash flows in a general cash flow stream}
+$$
+
+$$
+D = \text{Macaulay duration}
+$$
+
+$$
+w_i = \text{present-value weight of the } i\text{th cash flow}
+$$
+
+$$
+T = \text{maturity time of a zero coupon bond when written separately}
+$$
+
+$$
+\mu = \frac{\lambda}{m} = \text{per-period yield}
+$$
+
+$$
+\gamma = \frac{c}{m} = \text{coupon rate per payment period}
+$$
+
+In most examples in this lecture, the bond redeems at par, so $R=F$.
+
+## Bond Basic Notation
+
+A bond is a contract where the issuer borrows money from investors and
+promises future payments.
+
+If the bond lasts $N$ years and pays coupons $m$ times per year, then:
+
+$$
+n = Nm
+$$
+
+Each coupon payment is:
+
+$$
+\frac{cF}{m}
+$$
+
+The per-period yield used for discounting is:
+
+$$
+\frac{\lambda}{m}
+$$
+
+Usually, unless stated otherwise:
+
+$$
+R = F
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The coupon rate $c$ is quoted annually, but coupons are paid only $m$
+times per year, so each coupon is the annual coupon amount $cF$ split
+across $m$ payments:
+
+$$
+\frac{cF}{m}
+$$
+
+If the bond lasts $N$ years and pays $m$ times per year, then there are
+$Nm$ payment dates, which gives:
+
+$$
+n=Nm
+$$
+
+The nominal yield $\lambda$ is also quoted annually, so the matching
+per-period discount rate is:
+
+$$
+\frac{\lambda}{m}
+$$
+
+This is why coupon bonds are naturally priced period by period: both the
+coupon cash flows and the discounting are expressed on the same payment
+schedule.
+
+</details>
+
+## Valuing Bonds: Initial Price Formula
+
+The price of a bond is the present value of all future coupon payments
+plus the present value of the redemption value.
+
+For a coupon bond:
+
+$$
+P
+= \sum_{i=1}^{n}
+\frac{cF/m}{(1+\lambda/m)^i}
++ \frac{R}{(1+\lambda/m)^n}
+$$
+
+Interpretation:
+
+- $\frac{cF}{m}$ is each coupon payment.
+- $R$ is the redemption value paid at maturity.
+- $\frac{\lambda}{m}$ is the per-period yield.
+- $n$ is the total number of coupon periods to maturity.
+
+If $R = F$, then:
+
+$$
+P
+= \sum_{i=1}^{n}
+\frac{cF/m}{(1+\lambda/m)^i}
++ \frac{F}{(1+\lambda/m)^n}
+$$
+
+Using the ordinary annuity formula:
+
+$$
+P
+= F\left[
+\frac{1}{(1+\lambda/m)^n}
++ \frac{c}{\lambda}
+\left(1-\frac{1}{(1+\lambda/m)^n}\right)
+\right]
+$$
+
+Equivalently:
+
+$$
+P
+= F
++ F\left(\frac{c-\lambda}{\lambda}\right)
+\left[
+1-\frac{1}{(1+\lambda/m)^n}
+\right]
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Bond pricing is just present value:
+
+$$
+\text{price} = \text{PV of coupons} + \text{PV of redemption value}
+$$
+
+Each coupon equals $\frac{cF}{m}$ and arrives one period apart, so we
+discount the $i$th coupon by $(1+\lambda/m)^i$. The redemption value is
+paid at the final date, so it is discounted by $(1+\lambda/m)^n$.
+
+When $R=F$, the coupon part becomes an ordinary annuity, which gives the
+compact annuity form above. The last equivalent form is especially useful
+for intuition: it shows that price differs from par because the coupon
+rate $c$ may differ from the yield $\lambda$.
+
+More explicitly, the coupon leg is:
+
+$$
+\sum_{i=1}^{n}\frac{cF/m}{(1+\lambda/m)^i}
+=
+\frac{cF}{m}a_{\overline{n}|\,\lambda/m}
+$$
+
+and the redemption leg is:
+
+$$
+\frac{R}{(1+\lambda/m)^n}
+$$
+
+so the full price is just the sum of those two pieces.
+
+</details>
+
+## Makeham Formula
+
+Let:
+
+$$
+K = \frac{F}{(1+\lambda/m)^n}
+$$
+
+Here $K$ is the present value of the face value paid at maturity.
+
+The Makeham formula is:
+
+$$
+P = K + \frac{c}{\lambda}(F-K)
+$$
+
+This is another way to write the bond price when $R = F$.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The term $K$ isolates the discounted redemption payment. Then $F-K$
+captures the gap between the face value and its present value, and the
+factor $\frac{c}{\lambda}$ adjusts that gap according to how large the
+coupon rate is relative to the yield.
+
+So the Makeham formula is just a rearranged bond-pricing formula, but it
+makes the roles of redemption and coupons easier to separate.
+
+Starting from
+
+$$
+P
+= F\left[
+\frac{1}{(1+\lambda/m)^n}
++ \frac{c}{\lambda}
+\left(1-\frac{1}{(1+\lambda/m)^n}\right)
+\right],
+$$
+
+define
+
+$$
+K=\frac{F}{(1+\lambda/m)^n}.
+$$
+
+Then
+
+$$
+F-K
+= F\left(1-\frac{1}{(1+\lambda/m)^n}\right),
+$$
+
+so the formula becomes
+
+$$
+P = K + \frac{c}{\lambda}(F-K).
+$$
+
+</details>
+
+## Price Immediately After $k$ Payments
+
+Let $P_k$ be the bond price immediately after the $k$th coupon payment
+has been made.
+
+At that point, there are $n-k$ coupon payments remaining, plus the
+redemption value at maturity. Hence:
+
+$$
+P_k
+= \sum_{i=1}^{n-k}
+\frac{cF/m}{(1+\lambda/m)^i}
++ \frac{R}{(1+\lambda/m)^{n-k}}
+$$
+
+If $R = F$, this becomes:
+
+$$
+P_k
+= \sum_{i=1}^{n-k}
+\frac{cF/m}{(1+\lambda/m)^i}
++ \frac{F}{(1+\lambda/m)^{n-k}}
+$$
+
+The lecture also gives the recursive relation:
+
+$$
+P_{k+1}
+= P_k\left(1+\frac{\lambda}{m}\right)
+- \frac{cF}{m}
+$$
+
+Interpretation: after one period, the current price grows by the
+per-period yield, then the coupon payment is paid out.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Immediately after the $k$th coupon is paid, all earlier cash flows are
+gone. So the bond is worth only the present value of the remaining
+coupons and the final redemption payment.
+
+The recursive formula says:
+
+$$
+\text{next ex-coupon price}
+=
+\text{current ex-coupon price grown one period}
+-
+\text{coupon just paid}
+$$
+
+So the bond first earns one period of yield, then loses value when the
+next coupon is detached and paid to the bondholder.
+
+Algebraically, take the price formula for $P_k$, multiply it by
+$1+\lambda/m$, and compare it with the remaining-cash-flow formula for
+$P_{k+1}$. The only extra term is the coupon paid at the next date, which
+is why we subtract $\frac{cF}{m}$.
+
+</details>
+
+## Premium, Par, and Discount Bonds
+
+A bond is purchased at a premium if:
+
+$$
+P > F
+$$
+
+A bond is purchased at par if:
+
+$$
+P = F
+$$
+
+A bond is purchased at a discount if:
+
+$$
+P < F
+$$
+
+When $R = F$, the criteria are:
+
+$$
+P > F \iff c > \lambda
+$$
+
+$$
+P = F \iff c = \lambda
+$$
+
+$$
+P < F \iff c < \lambda
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+If the coupon rate $c$ is higher than the yield $\lambda$, the bond pays
+relatively attractive coupons, so investors are willing to pay more than
+par:
+
+$$
+P>F
+$$
+
+If the coupon rate exactly matches the yield, the bond is fairly priced at
+par:
+
+$$
+P=F
+$$
+
+If the coupon rate is below the yield, the coupons are unattractive
+relative to the market, so the price must fall below par:
+
+$$
+P<F
+$$
+
+This also follows directly from the equivalent form
+
+$$
+P
+= F
++ F\left(\frac{c-\lambda}{\lambda}\right)
+\left[
+1-\frac{1}{(1+\lambda/m)^n}
+\right].
+$$
+
+The bracketed term is positive, so the sign of $P-F$ is determined by the
+sign of $c-\lambda$.
+
+</details>
+
+## Zero Coupon Bond
+
+A zero coupon bond pays no coupons.
+
+The only cash flow is the redemption value $R$ at maturity. If maturity is
+at time $N$ and the bond discounts once per year, so $m=1$, then the
+nominal annual yield $\lambda$ is also the per-year yield, and:
+
+$$
+P = \frac{R}{(1+\lambda)^N}
+$$
+
+If the yield is nominal convertible $m$ times per year and there are $n$
+periods, the matching form is:
+
+$$
+P = \frac{R}{(1+\lambda/m)^n}
+$$
+
+For a zero coupon bond, all value comes from the final redemption
+payment.
+
+<details>
+<summary>Intuition / proof</summary>
+
+A zero coupon bond has only one future cash flow, so its price is just the
+present value of that single payment:
+
+$$
+P=\text{PV of }R
+$$
+
+There are no interim coupons, so the entire return comes from buying the
+bond now and receiving the redemption value at maturity.
+
+This is why zero coupon bonds are the simplest building blocks in term
+structure work: there is exactly one payment date and no intermediate cash
+flows to separate out.
+
+</details>
+
+## Perpetual Bond
+
+A perpetual bond, or consol, is a bond that never matures.
+
+It pays coupons forever. Since each coupon is $\frac{cF}{m}$ and the
+per-period yield is $\frac{\lambda}{m}$:
+
+$$
+P
+= \frac{cF/m}{\lambda/m}
+= \frac{cF}{\lambda}
+$$
+
+So:
+
+$$
+P = \frac{cF}{\lambda}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A perpetual bond is just a perpetuity. The payment each period is
+$\frac{cF}{m}$ and the discount rate per period is $\frac{\lambda}{m}$,
+so the perpetuity formula gives:
+
+$$
+\frac{\text{payment}}{\text{rate}}
+=
+\frac{cF/m}{\lambda/m}
+$$
+
+The $m$ cancels, leaving:
+
+$$
+P=\frac{cF}{\lambda}
+$$
+
+Intuitively, the price is large when the coupon stream is large and small
+when the market yield is high, exactly like any perpetuity.
+
+</details>
+
+## Macaulay Duration
+
+Macaulay duration is the weighted average time of the cash flows, using
+present-value weights.
+
+The weights are based on the present value of each cash payment.
+
+For a general cash flow stream with $q$ cash flows:
+
+$$
+C = \{(c_i,t_i): i = 1,2,\ldots,q\}
+$$
+
+the Macaulay duration $D$ is:
+
+$$
+D
+= \frac{
+\sum_{i=1}^q t_i \operatorname{PV}(\{(c_i,t_i)\})
+}{
+\operatorname{PV}(C)
+}
+$$
+
+Equivalently:
+
+$$
+D = \sum_{i=1}^q w_i t_i
+$$
+
+where:
+
+$$
+w_i
+= \frac{
+\operatorname{PV}(\{(c_i,t_i)\})
+}{
+\operatorname{PV}(C)
+}
+$$
+
+If all cash flows are non-negative, then:
+
+$$
+t_1 \le D \le t_q
+$$
+
+For a zero coupon bond with maturity $T$:
+
+$$
+D = T
+$$
+
+Macaulay duration is also related to how sensitive a bond price is to
+changes in interest rates.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Duration is a time average, but not an ordinary average. Each payment time
+is weighted by how important that cash flow is in present-value terms.
+
+Since the weights $w_i$ are present-value proportions, they satisfy:
+
+$$
+w_i \ge 0,
+\qquad
+\sum_{i=1}^q w_i = 1
+$$
+
+So duration is a weighted average of payment times, which explains why it
+must lie between the earliest and latest payment times when all cash flows
+are non-negative.
+
+For a zero coupon bond, there is only one cash flow at maturity, so all
+the weight is on that one date and:
+
+$$
+D=T
+$$
+
+The connection with interest-rate sensitivity is intuitive: if more of the
+bond's value comes from cash flows far in the future, then changes in
+discount rates affect the present value more strongly.
+
+</details>
+
+## Bond Duration
+
+For a bond with $n$ coupon payments, coupon frequency $m$, nominal
+coupon rate $c$, nominal yield $\lambda$, and redemption value $R$, the
+bond cash inflows are coupon payments plus the redemption value.
+
+The bond price is:
+
+$$
+P
+= \sum_{i=1}^{n}
+\frac{cF/m}{(1+\lambda/m)^i}
++ \frac{R}{(1+\lambda/m)^n}
+$$
+
+The bond duration is:
+
+$$
+D
+= \frac{1}{P}
+\left[
+\sum_{i=1}^{n}
+\frac{(i/m)(cF/m)}{(1+\lambda/m)^i}
++ \frac{(n/m)R}{(1+\lambda/m)^n}
+\right]
+$$
+
+If $R = F$, then the face value cancels out:
+
+$$
+D
+=
+\frac{
+\sum_{i=1}^{n}
+\frac{(i/m)(c/m)}{(1+\lambda/m)^i}
++ \frac{n/m}{(1+\lambda/m)^n}
+}{
+\sum_{i=1}^{n}
+\frac{c/m}{(1+\lambda/m)^i}
++ \frac{1}{(1+\lambda/m)^n}
+}
+$$
+
+Let:
+
+$$
+\mu = \frac{\lambda}{m}, \qquad \gamma = \frac{c}{m}
+$$
+
+Then:
+
+$$
+D
+=
+\frac{
+\sum_{i=1}^{n}
+\frac{(i/m)\gamma}{(1+\mu)^i}
++ \frac{n/m}{(1+\mu)^n}
+}{
+\sum_{i=1}^{n}
+\frac{\gamma}{(1+\mu)^i}
++ \frac{1}{(1+\mu)^n}
+}
+$$
+
+After simplification:
+
+$$
+D
+=
+\frac{1+\mu}{m\mu}
+-
+\frac{1+\mu+n(\gamma-\mu)}
+{m\gamma\left[(1+\mu)^n-1\right]+m\mu}
+$$
+
+If the bond is priced at par, then $P = F$ and $\mu = \gamma$. In this
+case:
+
+$$
+D
+=
+\frac{1+\mu}{m\mu}
+\left(
+1-\frac{1}{(1+\mu)^n}
+\right)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+This is just the Macaulay-duration formula applied to the bond's own cash
+flow stream.
+
+Each coupon at time $\frac{i}{m}$ is weighted by its present value, and
+the redemption value at time $\frac{n}{m}$ is weighted the same way.
+
+So duration is larger when more of the bond's value comes from later cash
+flows. That is why long maturities and low coupons tend to produce higher
+duration.
+
+When the bond is priced at par, the formula simplifies because the coupon
+rate and the yield match.
+
+The factor $\frac{1}{P}$ appears because the weights must add to $1$:
+
+$$
+w_i
+=
+\frac{\text{PV of cash flow }i}{\text{total bond price}}.
+$$
+
+So bond duration is not a new concept; it is the same weighted-average
+idea as Macaulay duration, specialized to coupon-bond cash flows.
+
+</details>
+
+## Duration for Perpetual Bonds
+
+For a perpetual bond, take $n \to \infty$ in the duration formula.
+
+The duration is:
+
+$$
+D
+= \frac{1+\mu}{m\mu}
+$$
+
+Since $\mu = \frac{\lambda}{m}$:
+
+$$
+D
+= \frac{1+\lambda/m}{\lambda}
+$$
+
+where $\lambda$ is the nominal annual yield.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Even though a perpetual bond pays forever, discounting makes far-future
+coupons matter less and less.
+
+So the weighted-average payment time stays finite, and the perpetual
+duration is the limiting value of the finite-bond duration formula as
+$n\to\infty$.
+
+This is a good reminder that "infinite maturity" does not force duration
+to be infinite. Present-value weights shrink for distant coupons, so the
+weighted average can still converge.
+
+</details>
+
+## Key Takeaways
+
+- A bond price is the present value of coupon payments plus redemption value.
+- The coupon rate $c$ determines the cash payments; the yield $\lambda$ discounts those payments.
+- If $R=F$, then $P>F$ iff $c>\lambda$, $P=F$ iff $c=\lambda$, and $P<F$ iff $c<\lambda$.
+- $P_k$ is the price immediately after the $k$th coupon payment.
+- A zero coupon bond has duration equal to its maturity.
+- Macaulay duration is a present-value-weighted average payment time.
+- For a fixed yield convention, higher duration generally means greater price sensitivity to yield changes.

--- a/NUS/QF1100/summary/Lecture 03.md
+++ b/NUS/QF1100/summary/Lecture 03.md
@@ -203,13 +203,13 @@ $$
 Using the ordinary annuity formula:
 
 $$
-P = F\left[ \frac{1}{(1+\lambda/m)^n} + \frac{c}{\lambda} \left(1-\frac{1}{(1+\lambda/m)^n}\right) \right]
+P = F\left( \frac{1}{(1+\lambda/m)^n} + \frac{c}{\lambda} \left(1-\frac{1}{(1+\lambda/m)^n}\right) \right)
 $$
 
 Equivalently:
 
 $$
-P = F + F\left(\frac{c-\lambda}{\lambda}\right) \left[ 1-\frac{1}{(1+\lambda/m)^n} \right]
+P = F + F\left(\frac{c-\lambda}{\lambda}\right) \left(1-\frac{1}{(1+\lambda/m)^n}\right)
 $$
 
 <details>
@@ -559,7 +559,7 @@ $$
 The bond duration is:
 
 $$
-D = \frac{1}{P} \left[ \sum_{i=1}^{n} \frac{(i/m)(cF/m)}{(1+\lambda/m)^i} + \frac{(n/m)R}{(1+\lambda/m)^n} \right]
+D = \frac{1}{P} \left( \sum_{i=1}^{n} \frac{(i/m)(cF/m)}{(1+\lambda/m)^i} + \frac{(n/m)R}{(1+\lambda/m)^n} \right)
 $$
 
 If $R = F$, then the face value cancels out:
@@ -583,7 +583,7 @@ $$
 After simplification:
 
 $$
-D = \frac{1+\mu}{m\mu} - \frac{1+\mu+n(\gamma-\mu)} {m\gamma\left[(1+\mu)^n-1\right]+m\mu}
+D = \frac{1+\mu}{m\mu} - \frac{1+\mu+n(\gamma-\mu)} {m\gamma\left((1+\mu)^n-1\right)+m\mu}
 $$
 
 If the bond is priced at par, then $P = F$ and $\mu = \gamma$. In this

--- a/NUS/QF1100/summary/Lecture 03.md
+++ b/NUS/QF1100/summary/Lecture 03.md
@@ -158,17 +158,17 @@ The coupon rate $c$ is quoted annually, but coupons are paid only $m$
 times per year, so each coupon is the annual coupon amount $cF$ split
 across $m$ payments:
 
-$\displaystyle \frac{cF}{m}$
+$\frac{cF}{m}$
 
 If the bond lasts $N$ years and pays $m$ times per year, then there are
 $Nm$ payment dates, which gives:
 
-$\displaystyle n=Nm$
+$n=Nm$
 
 The nominal yield $\lambda$ is also quoted annually, so the matching
 per-period discount rate is:
 
-$\displaystyle \frac{\lambda}{m}$
+$\frac{\lambda}{m}$
 
 This is why coupon bonds are naturally priced period by period: both the
 coupon cash flows and the discounting are expressed on the same payment
@@ -233,7 +233,7 @@ $$
 
 Bond pricing is just present value:
 
-$\displaystyle \text{price} = \text{PV of coupons} + \text{PV of redemption value}$
+Price = PV of coupons + PV of redemption value.
 
 Each coupon equals $\frac{cF}{m}$ and arrives one period apart, so we
 discount the $i$th coupon by $(1+\lambda/m)^i$. The redemption value is
@@ -246,11 +246,11 @@ rate $c$ may differ from the yield $\lambda$.
 
 More explicitly, the coupon leg is:
 
-$\displaystyle \sum_{i=1}^{n}\frac{cF/m}{(1+\lambda/m)^i} = \frac{cF}{m}a_{\overline{n}|\,\lambda/m}$
+$\sum_{i=1}^{n}\frac{cF/m}{(1+\lambda/m)^i} = \frac{cF}{m}a_{\overline{n}|\,\lambda/m}$
 
 and the redemption leg is:
 
-$\displaystyle \frac{R}{(1+\lambda/m)^n}$
+$\frac{R}{(1+\lambda/m)^n}$
 
 so the full price is just the sum of those two pieces.
 
@@ -287,19 +287,19 @@ makes the roles of redemption and coupons easier to separate.
 
 Starting from
 
-$\displaystyle P = F\left[ \frac{1}{(1+\lambda/m)^n} + \frac{c}{\lambda} \left(1-\frac{1}{(1+\lambda/m)^n}\right) \right],$
+$P = F[ \frac{1}{(1+\lambda/m)^n} + \frac{c}{\lambda} (1-\frac{1}{(1+\lambda/m)^n}) ],$
 
 define
 
-$\displaystyle K=\frac{F}{(1+\lambda/m)^n}.$
+$K=\frac{F}{(1+\lambda/m)^n}.$
 
 Then
 
-$\displaystyle F-K = F\left(1-\frac{1}{(1+\lambda/m)^n}\right),$
+$F-K = F(1-\frac{1}{(1+\lambda/m)^n}),$
 
 so the formula becomes
 
-$\displaystyle P = K + \frac{c}{\lambda}(F-K).$
+$P = K + \frac{c}{\lambda}(F-K).$
 
 </details>
 
@@ -347,7 +347,8 @@ coupons and the final redemption payment.
 
 The recursive formula says:
 
-$\displaystyle \text{next ex-coupon price} = \text{current ex-coupon price grown one period} - \text{coupon just paid}$
+next ex-coupon price = current ex-coupon price grown one period - coupon
+just paid.
 
 So the bond first earns one period of yield, then loses value when the
 next coupon is detached and paid to the bondholder.
@@ -400,21 +401,21 @@ If the coupon rate $c$ is higher than the yield $\lambda$, the bond pays
 relatively attractive coupons, so investors are willing to pay more than
 par:
 
-$\displaystyle P>F$
+$P>F$
 
 If the coupon rate exactly matches the yield, the bond is fairly priced at
 par:
 
-$\displaystyle P=F$
+$P=F$
 
 If the coupon rate is below the yield, the coupons are unattractive
 relative to the market, so the price must fall below par:
 
-$\displaystyle P<F$
+$P<F$
 
 This also follows directly from the equivalent form
 
-$\displaystyle P = F + F\left(\frac{c-\lambda}{\lambda}\right) \left[ 1-\frac{1}{(1+\lambda/m)^n} \right].$
+$P = F + F(\frac{c-\lambda}{\lambda}) [ 1-\frac{1}{(1+\lambda/m)^n} ].$
 
 The bracketed term is positive, so the sign of $P-F$ is determined by the
 sign of $c-\lambda$.
@@ -449,7 +450,7 @@ payment.
 A zero coupon bond has only one future cash flow, so its price is just the
 present value of that single payment:
 
-$\displaystyle P=\text{PV of }R$
+$P$ is the present value of $R$.
 
 There are no interim coupons, so the entire return comes from buying the
 bond now and receiving the redemption value at maturity.
@@ -486,11 +487,12 @@ A perpetual bond is just a perpetuity. The payment each period is
 $\frac{cF}{m}$ and the discount rate per period is $\frac{\lambda}{m}$,
 so the perpetuity formula gives:
 
-$\displaystyle \frac{\text{payment}}{\text{rate}} = \frac{cF/m}{\lambda/m}$
+So the perpetuity rule "payment divided by rate" becomes
+$P = \frac{cF/m}{\lambda/m}$.
 
 The $m$ cancels, leaving:
 
-$\displaystyle P=\frac{cF}{\lambda}$
+$P=\frac{cF}{\lambda}$
 
 Intuitively, the price is large when the coupon stream is large and small
 when the market yield is high, exactly like any perpetuity.
@@ -561,7 +563,7 @@ is weighted by how important that cash flow is in present-value terms.
 
 Since the weights $w_i$ are present-value proportions, they satisfy:
 
-$\displaystyle w_i \ge 0, \qquad \sum_{i=1}^q w_i = 1$
+$w_i \ge 0$ and $\sum_{i=1}^q w_i = 1$
 
 So duration is a weighted average of payment times, which explains why it
 must lie between the earliest and latest payment times when all cash flows
@@ -570,7 +572,7 @@ are non-negative.
 For a zero coupon bond, there is only one cash flow at maturity, so all
 the weight is on that one date and:
 
-$\displaystyle D=T$
+$D=T$
 
 The connection with interest-rate sensitivity is intuitive: if more of the
 bond's value comes from cash flows far in the future, then changes in
@@ -682,9 +684,9 @@ duration.
 When the bond is priced at par, the formula simplifies because the coupon
 rate and the yield match.
 
-The factor $\frac{1}{P}$ appears because the weights must add to $1$:
-
-$\displaystyle w_i = \frac{\text{PV of cash flow }i}{\text{total bond price}}.$
+The factor $\frac{1}{P}$ appears because the weights must add to $1$.
+Equivalently, $w_i$ is the present value of cash flow $i$ divided by the
+total bond price $P$.
 
 So bond duration is not a new concept; it is the same weighted-average
 idea as Macaulay duration, specialized to coupon-bond cash flows.

--- a/NUS/QF1100/summary/Lecture 03.md
+++ b/NUS/QF1100/summary/Lecture 03.md
@@ -73,11 +73,11 @@ C = \text{general cash flow stream}
 $$
 
 $$
-\operatorname{PV}(C) = \text{present value of cash flow stream } C
+\mathrm{PV}(C) = \text{present value of cash flow stream } C
 $$
 
 $$
-\operatorname{PV}(\{(c_i,t_i)\}) = \text{present value of the single cash flow } c_i \text{ at time } t_i
+\mathrm{PV}(\{(c_i,t_i)\}) = \text{present value of the single cash flow } c_i \text{ at time } t_i
 $$
 
 $$
@@ -184,10 +184,7 @@ plus the present value of the redemption value.
 For a coupon bond:
 
 $$
-P
-= \sum_{i=1}^{n}
-\frac{cF/m}{(1+\lambda/m)^i}
-+ \frac{R}{(1+\lambda/m)^n}
+P = \sum_{i=1}^{n} \frac{cF/m}{(1+\lambda/m)^i} + \frac{R}{(1+\lambda/m)^n}
 $$
 
 Interpretation:
@@ -200,32 +197,19 @@ Interpretation:
 If $R = F$, then:
 
 $$
-P
-= \sum_{i=1}^{n}
-\frac{cF/m}{(1+\lambda/m)^i}
-+ \frac{F}{(1+\lambda/m)^n}
+P = \sum_{i=1}^{n} \frac{cF/m}{(1+\lambda/m)^i} + \frac{F}{(1+\lambda/m)^n}
 $$
 
 Using the ordinary annuity formula:
 
 $$
-P
-= F\left[
-\frac{1}{(1+\lambda/m)^n}
-+ \frac{c}{\lambda}
-\left(1-\frac{1}{(1+\lambda/m)^n}\right)
-\right]
+P = F\left[ \frac{1}{(1+\lambda/m)^n} + \frac{c}{\lambda} \left(1-\frac{1}{(1+\lambda/m)^n}\right) \right]
 $$
 
 Equivalently:
 
 $$
-P
-= F
-+ F\left(\frac{c-\lambda}{\lambda}\right)
-\left[
-1-\frac{1}{(1+\lambda/m)^n}
-\right]
+P = F + F\left(\frac{c-\lambda}{\lambda}\right) \left[ 1-\frac{1}{(1+\lambda/m)^n} \right]
 $$
 
 <details>
@@ -312,27 +296,19 @@ At that point, there are $n-k$ coupon payments remaining, plus the
 redemption value at maturity. Hence:
 
 $$
-P_k
-= \sum_{i=1}^{n-k}
-\frac{cF/m}{(1+\lambda/m)^i}
-+ \frac{R}{(1+\lambda/m)^{n-k}}
+P_k = \sum_{i=1}^{n-k} \frac{cF/m}{(1+\lambda/m)^i} + \frac{R}{(1+\lambda/m)^{n-k}}
 $$
 
 If $R = F$, this becomes:
 
 $$
-P_k
-= \sum_{i=1}^{n-k}
-\frac{cF/m}{(1+\lambda/m)^i}
-+ \frac{F}{(1+\lambda/m)^{n-k}}
+P_k = \sum_{i=1}^{n-k} \frac{cF/m}{(1+\lambda/m)^i} + \frac{F}{(1+\lambda/m)^{n-k}}
 $$
 
 The lecture also gives the recursive relation:
 
 $$
-P_{k+1}
-= P_k\left(1+\frac{\lambda}{m}\right)
-- \frac{cF}{m}
+P_{k+1} = P_k\left(1+\frac{\lambda}{m}\right) - \frac{cF}{m}
 $$
 
 Interpretation: after one period, the current price grows by the
@@ -469,9 +445,7 @@ It pays coupons forever. Since each coupon is $\frac{cF}{m}$ and the
 per-period yield is $\frac{\lambda}{m}$:
 
 $$
-P
-= \frac{cF/m}{\lambda/m}
-= \frac{cF}{\lambda}
+P = \frac{cF/m}{\lambda/m} = \frac{cF}{\lambda}
 $$
 
 So:
@@ -515,12 +489,7 @@ $$
 the Macaulay duration $D$ is:
 
 $$
-D
-= \frac{
-\sum_{i=1}^q t_i \operatorname{PV}(\{(c_i,t_i)\})
-}{
-\operatorname{PV}(C)
-}
+D = \frac{ \sum_{i=1}^q t_i \mathrm{PV}(\{(c_i,t_i)\}) }{ \mathrm{PV}(C) }
 $$
 
 Equivalently:
@@ -532,12 +501,7 @@ $$
 where:
 
 $$
-w_i
-= \frac{
-\operatorname{PV}(\{(c_i,t_i)\})
-}{
-\operatorname{PV}(C)
-}
+w_i = \frac{ \mathrm{PV}(\{(c_i,t_i)\}) }{ \mathrm{PV}(C) }
 $$
 
 If all cash flows are non-negative, then:
@@ -589,38 +553,19 @@ bond cash inflows are coupon payments plus the redemption value.
 The bond price is:
 
 $$
-P
-= \sum_{i=1}^{n}
-\frac{cF/m}{(1+\lambda/m)^i}
-+ \frac{R}{(1+\lambda/m)^n}
+P = \sum_{i=1}^{n} \frac{cF/m}{(1+\lambda/m)^i} + \frac{R}{(1+\lambda/m)^n}
 $$
 
 The bond duration is:
 
 $$
-D
-= \frac{1}{P}
-\left[
-\sum_{i=1}^{n}
-\frac{(i/m)(cF/m)}{(1+\lambda/m)^i}
-+ \frac{(n/m)R}{(1+\lambda/m)^n}
-\right]
+D = \frac{1}{P} \left[ \sum_{i=1}^{n} \frac{(i/m)(cF/m)}{(1+\lambda/m)^i} + \frac{(n/m)R}{(1+\lambda/m)^n} \right]
 $$
 
 If $R = F$, then the face value cancels out:
 
 $$
-D
-=
-\frac{
-\sum_{i=1}^{n}
-\frac{(i/m)(c/m)}{(1+\lambda/m)^i}
-+ \frac{n/m}{(1+\lambda/m)^n}
-}{
-\sum_{i=1}^{n}
-\frac{c/m}{(1+\lambda/m)^i}
-+ \frac{1}{(1+\lambda/m)^n}
-}
+D = \frac{ \sum_{i=1}^{n} \frac{(i/m)(c/m)}{(1+\lambda/m)^i} + \frac{n/m}{(1+\lambda/m)^n} }{ \sum_{i=1}^{n} \frac{c/m}{(1+\lambda/m)^i} + \frac{1}{(1+\lambda/m)^n} }
 $$
 
 Let:
@@ -632,40 +577,20 @@ $$
 Then:
 
 $$
-D
-=
-\frac{
-\sum_{i=1}^{n}
-\frac{(i/m)\gamma}{(1+\mu)^i}
-+ \frac{n/m}{(1+\mu)^n}
-}{
-\sum_{i=1}^{n}
-\frac{\gamma}{(1+\mu)^i}
-+ \frac{1}{(1+\mu)^n}
-}
+D = \frac{ \sum_{i=1}^{n} \frac{(i/m)\gamma}{(1+\mu)^i} + \frac{n/m}{(1+\mu)^n} }{ \sum_{i=1}^{n} \frac{\gamma}{(1+\mu)^i} + \frac{1}{(1+\mu)^n} }
 $$
 
 After simplification:
 
 $$
-D
-=
-\frac{1+\mu}{m\mu}
--
-\frac{1+\mu+n(\gamma-\mu)}
-{m\gamma\left[(1+\mu)^n-1\right]+m\mu}
+D = \frac{1+\mu}{m\mu} - \frac{1+\mu+n(\gamma-\mu)} {m\gamma\left[(1+\mu)^n-1\right]+m\mu}
 $$
 
 If the bond is priced at par, then $P = F$ and $\mu = \gamma$. In this
 case:
 
 $$
-D
-=
-\frac{1+\mu}{m\mu}
-\left(
-1-\frac{1}{(1+\mu)^n}
-\right)
+D = \frac{1+\mu}{m\mu} \left( 1-\frac{1}{(1+\mu)^n} \right)
 $$
 
 <details>
@@ -700,15 +625,13 @@ For a perpetual bond, take $n \to \infty$ in the duration formula.
 The duration is:
 
 $$
-D
-= \frac{1+\mu}{m\mu}
+D = \frac{1+\mu}{m\mu}
 $$
 
 Since $\mu = \frac{\lambda}{m}$:
 
 $$
-D
-= \frac{1+\lambda/m}{\lambda}
+D = \frac{1+\lambda/m}{\lambda}
 $$
 
 where $\lambda$ is the nominal annual yield.

--- a/NUS/QF1100/summary/Lecture 03.md
+++ b/NUS/QF1100/summary/Lecture 03.md
@@ -158,23 +158,17 @@ The coupon rate $c$ is quoted annually, but coupons are paid only $m$
 times per year, so each coupon is the annual coupon amount $cF$ split
 across $m$ payments:
 
-$$
-\frac{cF}{m}
-$$
+$\displaystyle \frac{cF}{m}$
 
 If the bond lasts $N$ years and pays $m$ times per year, then there are
 $Nm$ payment dates, which gives:
 
-$$
-n=Nm
-$$
+$\displaystyle n=Nm$
 
 The nominal yield $\lambda$ is also quoted annually, so the matching
 per-period discount rate is:
 
-$$
-\frac{\lambda}{m}
-$$
+$\displaystyle \frac{\lambda}{m}$
 
 This is why coupon bonds are naturally priced period by period: both the
 coupon cash flows and the discounting are expressed on the same payment
@@ -239,9 +233,7 @@ $$
 
 Bond pricing is just present value:
 
-$$
-\text{price} = \text{PV of coupons} + \text{PV of redemption value}
-$$
+$\displaystyle \text{price} = \text{PV of coupons} + \text{PV of redemption value}$
 
 Each coupon equals $\frac{cF}{m}$ and arrives one period apart, so we
 discount the $i$th coupon by $(1+\lambda/m)^i$. The redemption value is
@@ -254,17 +246,11 @@ rate $c$ may differ from the yield $\lambda$.
 
 More explicitly, the coupon leg is:
 
-$$
-\sum_{i=1}^{n}\frac{cF/m}{(1+\lambda/m)^i}
-=
-\frac{cF}{m}a_{\overline{n}|\,\lambda/m}
-$$
+$\displaystyle \sum_{i=1}^{n}\frac{cF/m}{(1+\lambda/m)^i} = \frac{cF}{m}a_{\overline{n}|\,\lambda/m}$
 
 and the redemption leg is:
 
-$$
-\frac{R}{(1+\lambda/m)^n}
-$$
+$\displaystyle \frac{R}{(1+\lambda/m)^n}$
 
 so the full price is just the sum of those two pieces.
 
@@ -301,33 +287,19 @@ makes the roles of redemption and coupons easier to separate.
 
 Starting from
 
-$$
-P
-= F\left[
-\frac{1}{(1+\lambda/m)^n}
-+ \frac{c}{\lambda}
-\left(1-\frac{1}{(1+\lambda/m)^n}\right)
-\right],
-$$
+$\displaystyle P = F\left[ \frac{1}{(1+\lambda/m)^n} + \frac{c}{\lambda} \left(1-\frac{1}{(1+\lambda/m)^n}\right) \right],$
 
 define
 
-$$
-K=\frac{F}{(1+\lambda/m)^n}.
-$$
+$\displaystyle K=\frac{F}{(1+\lambda/m)^n}.$
 
 Then
 
-$$
-F-K
-= F\left(1-\frac{1}{(1+\lambda/m)^n}\right),
-$$
+$\displaystyle F-K = F\left(1-\frac{1}{(1+\lambda/m)^n}\right),$
 
 so the formula becomes
 
-$$
-P = K + \frac{c}{\lambda}(F-K).
-$$
+$\displaystyle P = K + \frac{c}{\lambda}(F-K).$
 
 </details>
 
@@ -375,13 +347,7 @@ coupons and the final redemption payment.
 
 The recursive formula says:
 
-$$
-\text{next ex-coupon price}
-=
-\text{current ex-coupon price grown one period}
--
-\text{coupon just paid}
-$$
+$\displaystyle \text{next ex-coupon price} = \text{current ex-coupon price grown one period} - \text{coupon just paid}$
 
 So the bond first earns one period of yield, then loses value when the
 next coupon is detached and paid to the bondholder.
@@ -434,34 +400,21 @@ If the coupon rate $c$ is higher than the yield $\lambda$, the bond pays
 relatively attractive coupons, so investors are willing to pay more than
 par:
 
-$$
-P>F
-$$
+$\displaystyle P>F$
 
 If the coupon rate exactly matches the yield, the bond is fairly priced at
 par:
 
-$$
-P=F
-$$
+$\displaystyle P=F$
 
 If the coupon rate is below the yield, the coupons are unattractive
 relative to the market, so the price must fall below par:
 
-$$
-P<F
-$$
+$\displaystyle P<F$
 
 This also follows directly from the equivalent form
 
-$$
-P
-= F
-+ F\left(\frac{c-\lambda}{\lambda}\right)
-\left[
-1-\frac{1}{(1+\lambda/m)^n}
-\right].
-$$
+$\displaystyle P = F + F\left(\frac{c-\lambda}{\lambda}\right) \left[ 1-\frac{1}{(1+\lambda/m)^n} \right].$
 
 The bracketed term is positive, so the sign of $P-F$ is determined by the
 sign of $c-\lambda$.
@@ -496,9 +449,7 @@ payment.
 A zero coupon bond has only one future cash flow, so its price is just the
 present value of that single payment:
 
-$$
-P=\text{PV of }R
-$$
+$\displaystyle P=\text{PV of }R$
 
 There are no interim coupons, so the entire return comes from buying the
 bond now and receiving the redemption value at maturity.
@@ -535,17 +486,11 @@ A perpetual bond is just a perpetuity. The payment each period is
 $\frac{cF}{m}$ and the discount rate per period is $\frac{\lambda}{m}$,
 so the perpetuity formula gives:
 
-$$
-\frac{\text{payment}}{\text{rate}}
-=
-\frac{cF/m}{\lambda/m}
-$$
+$\displaystyle \frac{\text{payment}}{\text{rate}} = \frac{cF/m}{\lambda/m}$
 
 The $m$ cancels, leaving:
 
-$$
-P=\frac{cF}{\lambda}
-$$
+$\displaystyle P=\frac{cF}{\lambda}$
 
 Intuitively, the price is large when the coupon stream is large and small
 when the market yield is high, exactly like any perpetuity.
@@ -616,11 +561,7 @@ is weighted by how important that cash flow is in present-value terms.
 
 Since the weights $w_i$ are present-value proportions, they satisfy:
 
-$$
-w_i \ge 0,
-\qquad
-\sum_{i=1}^q w_i = 1
-$$
+$\displaystyle w_i \ge 0, \qquad \sum_{i=1}^q w_i = 1$
 
 So duration is a weighted average of payment times, which explains why it
 must lie between the earliest and latest payment times when all cash flows
@@ -629,9 +570,7 @@ are non-negative.
 For a zero coupon bond, there is only one cash flow at maturity, so all
 the weight is on that one date and:
 
-$$
-D=T
-$$
+$\displaystyle D=T$
 
 The connection with interest-rate sensitivity is intuitive: if more of the
 bond's value comes from cash flows far in the future, then changes in
@@ -745,11 +684,7 @@ rate and the yield match.
 
 The factor $\frac{1}{P}$ appears because the weights must add to $1$:
 
-$$
-w_i
-=
-\frac{\text{PV of cash flow }i}{\text{total bond price}}.
-$$
+$\displaystyle w_i = \frac{\text{PV of cash flow }i}{\text{total bond price}}.$
 
 So bond duration is not a new concept; it is the same weighted-average
 idea as Macaulay duration, specialized to coupon-bond cash flows.

--- a/NUS/QF1100/summary/Lecture 04.md
+++ b/NUS/QF1100/summary/Lecture 04.md
@@ -136,12 +136,12 @@ The spot rate $s_t$ is the annualized rate implied for maturity $t$.
 If one unit of money grows for $t$ years at the spot rate for maturity
 $t$, then under yearly compounding it becomes:
 
-$\displaystyle (1+s_t)^t$
+$(1+s_t)^t$
 
 So if a future payment $C_t$ is due at time $t$, the amount today that
 grows to that payment must be:
 
-$\displaystyle \frac{C_t}{(1+s_t)^t}$
+$\frac{C_t}{(1+s_t)^t}$
 
 This is why spot rates are fundamental: each maturity has its own
 discount rate, rather than forcing all cash flows to use one constant
@@ -179,16 +179,16 @@ rate because it has only one cash flow.
 
 Its price must equal the present value of the redemption payment:
 
-$\displaystyle P=\frac{R}{(1+s_n)^n}$
+$P=\frac{R}{(1+s_n)^n}$
 
 Since $P$ and $R$ are known from the bond, the only unknown is $s_n$.
 Rearranging gives:
 
-$\displaystyle (1+s_n)^n = \frac{R}{P}$
+$(1+s_n)^n = \frac{R}{P}$
 
 and then:
 
-$\displaystyle s_n = \left(\frac{R}{P}\right)^{1/n}-1$
+$s_n = (\frac{R}{P})^{1/n}-1$
 
 This is why zero coupon bonds "isolate" spot rates directly.
 
@@ -230,7 +230,7 @@ So:
 
 The convention
 
-$\displaystyle f_{0,t}=s_t$
+$f_{0,t}=s_t$
 
 simply says a spot rate is a special case of a forward rate whose starting
 date is today.
@@ -293,22 +293,22 @@ To reach time $k$, you can:
 
 Strategy 1 gives:
 
-$\displaystyle (1+s_k)^k$
+$(1+s_k)^k$
 
 Strategy 2 gives:
 
-$\displaystyle (1+s_j)^j(1+f_{j,k})^{k-j}$
+$(1+s_j)^j(1+f_{j,k})^{k-j}$
 
 No arbitrage forces these to be equal, which gives the forward-rate
 formula after rearranging.
 
 To solve explicitly:
 
-$\displaystyle (1+f_{j,k})^{k-j} = \frac{(1+s_k)^k}{(1+s_j)^j}$
+$(1+f_{j,k})^{k-j} = \frac{(1+s_k)^k}{(1+s_j)^j}$
 
 so:
 
-$\displaystyle 1+f_{j,k} = \left[ \frac{(1+s_k)^k}{(1+s_j)^j} \right]^{1/(k-j)}$
+$1+f_{j,k} = [ \frac{(1+s_k)^k}{(1+s_j)^j} ]^{1/(k-j)}$
 
 and subtracting $1$ gives the forward-rate formula.
 
@@ -340,7 +340,7 @@ spot rate for that maturity.
 The payment at time $1$ is discounted by $s_1$, the payment at time $2$
 is discounted by $s_2$, and so on:
 
-$\displaystyle \frac{C_1}{1+s_1},\quad \frac{C_2}{(1+s_2)^2},\quad \ldots,\quad \frac{C_n}{(1+s_n)^n}$
+$\frac{C_1}{1+s_1},\quad \frac{C_2}{(1+s_2)^2},\quad \ldots,\quad \frac{C_n}{(1+s_n)^n}$
 
 Then the total price is the sum of these present values.
 
@@ -424,7 +424,7 @@ earlier coupon cash flows of a later bond can already be priced.
 In the $n$-period bond formula, all terms except the last one involve
 spot rates that were solved earlier:
 
-$\displaystyle s_1,s_2,\ldots,s_{n-1}$
+$s_1,s_2,\ldots,s_{n-1}$
 
 So after subtracting the present value of the earlier coupon payments from
 the bond price, the remaining unknown part is the final term involving
@@ -436,7 +436,7 @@ $s_2$, then $s_3$, and so on.
 More explicitly, once the earlier terms are moved to the left-hand side,
 we get:
 
-$\displaystyle P_n - \frac{cF/m}{1+s_1} - \frac{cF/m}{(1+s_2)^2} - \cdots - \frac{cF/m}{(1+s_{n-1})^{n-1}} = \frac{cF/m+R}{(1+s_n)^n}$
+$P_n - \frac{cF/m}{1+s_1} - \frac{cF/m}{(1+s_2)^2} - \cdots - \frac{cF/m}{(1+s_{n-1})^{n-1}} = \frac{cF/m+R}{(1+s_n)^n}$
 
 and now the only unknown in the equation is $s_n$.
 

--- a/NUS/QF1100/summary/Lecture 04.md
+++ b/NUS/QF1100/summary/Lecture 04.md
@@ -136,16 +136,12 @@ The spot rate $s_t$ is the annualized rate implied for maturity $t$.
 If one unit of money grows for $t$ years at the spot rate for maturity
 $t$, then under yearly compounding it becomes:
 
-$$
-(1+s_t)^t
-$$
+$\displaystyle (1+s_t)^t$
 
 So if a future payment $C_t$ is due at time $t$, the amount today that
 grows to that payment must be:
 
-$$
-\frac{C_t}{(1+s_t)^t}
-$$
+$\displaystyle \frac{C_t}{(1+s_t)^t}$
 
 This is why spot rates are fundamental: each maturity has its own
 discount rate, rather than forcing all cash flows to use one constant
@@ -183,22 +179,16 @@ rate because it has only one cash flow.
 
 Its price must equal the present value of the redemption payment:
 
-$$
-P=\frac{R}{(1+s_n)^n}
-$$
+$\displaystyle P=\frac{R}{(1+s_n)^n}$
 
 Since $P$ and $R$ are known from the bond, the only unknown is $s_n$.
 Rearranging gives:
 
-$$
-(1+s_n)^n = \frac{R}{P}
-$$
+$\displaystyle (1+s_n)^n = \frac{R}{P}$
 
 and then:
 
-$$
-s_n = \left(\frac{R}{P}\right)^{1/n}-1
-$$
+$\displaystyle s_n = \left(\frac{R}{P}\right)^{1/n}-1$
 
 This is why zero coupon bonds "isolate" spot rates directly.
 
@@ -240,9 +230,7 @@ So:
 
 The convention
 
-$$
-f_{0,t}=s_t
-$$
+$\displaystyle f_{0,t}=s_t$
 
 simply says a spot rate is a special case of a forward rate whose starting
 date is today.
@@ -305,36 +293,22 @@ To reach time $k$, you can:
 
 Strategy 1 gives:
 
-$$
-(1+s_k)^k
-$$
+$\displaystyle (1+s_k)^k$
 
 Strategy 2 gives:
 
-$$
-(1+s_j)^j(1+f_{j,k})^{k-j}
-$$
+$\displaystyle (1+s_j)^j(1+f_{j,k})^{k-j}$
 
 No arbitrage forces these to be equal, which gives the forward-rate
 formula after rearranging.
 
 To solve explicitly:
 
-$$
-(1+f_{j,k})^{k-j}
-=
-\frac{(1+s_k)^k}{(1+s_j)^j}
-$$
+$\displaystyle (1+f_{j,k})^{k-j} = \frac{(1+s_k)^k}{(1+s_j)^j}$
 
 so:
 
-$$
-1+f_{j,k}
-=
-\left[
-\frac{(1+s_k)^k}{(1+s_j)^j}
-\right]^{1/(k-j)}
-$$
+$\displaystyle 1+f_{j,k} = \left[ \frac{(1+s_k)^k}{(1+s_j)^j} \right]^{1/(k-j)}$
 
 and subtracting $1$ gives the forward-rate formula.
 
@@ -366,12 +340,7 @@ spot rate for that maturity.
 The payment at time $1$ is discounted by $s_1$, the payment at time $2$
 is discounted by $s_2$, and so on:
 
-$$
-\frac{C_1}{1+s_1},\quad
-\frac{C_2}{(1+s_2)^2},\quad
-\ldots,\quad
-\frac{C_n}{(1+s_n)^n}
-$$
+$\displaystyle \frac{C_1}{1+s_1},\quad \frac{C_2}{(1+s_2)^2},\quad \ldots,\quad \frac{C_n}{(1+s_n)^n}$
 
 Then the total price is the sum of these present values.
 
@@ -455,9 +424,7 @@ earlier coupon cash flows of a later bond can already be priced.
 In the $n$-period bond formula, all terms except the last one involve
 spot rates that were solved earlier:
 
-$$
-s_1,s_2,\ldots,s_{n-1}
-$$
+$\displaystyle s_1,s_2,\ldots,s_{n-1}$
 
 So after subtracting the present value of the earlier coupon payments from
 the bond price, the remaining unknown part is the final term involving
@@ -469,15 +436,7 @@ $s_2$, then $s_3$, and so on.
 More explicitly, once the earlier terms are moved to the left-hand side,
 we get:
 
-$$
-P_n
-- \frac{cF/m}{1+s_1}
-- \frac{cF/m}{(1+s_2)^2}
-- \cdots
-- \frac{cF/m}{(1+s_{n-1})^{n-1}}
-=
-\frac{cF/m+R}{(1+s_n)^n}
-$$
+$\displaystyle P_n - \frac{cF/m}{1+s_1} - \frac{cF/m}{(1+s_2)^2} - \cdots - \frac{cF/m}{(1+s_{n-1})^{n-1}} = \frac{cF/m+R}{(1+s_n)^n}$
 
 and now the only unknown in the equation is $s_n$.
 

--- a/NUS/QF1100/summary/Lecture 04.md
+++ b/NUS/QF1100/summary/Lecture 04.md
@@ -45,7 +45,7 @@ C_1,C_2,\ldots,C_n = \text{cash flows paid at times } 1,2,\ldots,n
 $$
 
 $$
-\operatorname{PV} = \text{present value}
+\mathrm{PV} = \text{present value}
 $$
 
 $$
@@ -122,8 +122,7 @@ is the accumulation factor for holding money from time $0$ to time $t$.
 Equivalently, if a cash flow $C_t$ is paid at time $t$, its present value is:
 
 $$
-\operatorname{PV}
-= \frac{C_t}{(1+s_t)^t}
+\mathrm{PV} = \frac{C_t}{(1+s_t)^t}
 $$
 
 The collection of spot rates defines the term structure of interest rates.
@@ -167,8 +166,7 @@ $$
 Solving for $s_n$:
 
 $$
-s_n
-= \left(\frac{R}{P}\right)^{1/n} - 1
+s_n = \left(\frac{R}{P}\right)^{1/n} - 1
 $$
 
 <details>
@@ -245,8 +243,7 @@ spot rates cover the whole period from now to a future date.
 The key no-arbitrage relationship is:
 
 $$
-(1+s_k)^k
-= (1+s_j)^j(1+f_{j,k})^{k-j}
+(1+s_k)^k = (1+s_j)^j(1+f_{j,k})^{k-j}
 $$
 
 for:
@@ -258,12 +255,7 @@ $$
 Solving for the forward rate:
 
 $$
-f_{j,k}
-=
-\left[
-\frac{(1+s_k)^k}{(1+s_j)^j}
-\right]^{1/(k-j)}
-- 1
+f_{j,k} = \left[ \frac{(1+s_k)^k}{(1+s_j)^j} \right]^{1/(k-j)} - 1
 $$
 
 For the one-period forward rate from year $1$ to year $2$:
@@ -275,8 +267,7 @@ $$
 Thus:
 
 $$
-f_{1,2}
-= \frac{(1+s_2)^2}{1+s_1} - 1
+f_{1,2} = \frac{(1+s_2)^2}{1+s_1} - 1
 $$
 
 <details>
@@ -322,11 +313,7 @@ rate matching its payment time.
 For cash flows $C_1,C_2,\ldots,C_n$:
 
 $$
-P
-= \frac{C_1}{1+s_1}
-+ \frac{C_2}{(1+s_2)^2}
-+ \cdots
-+ \frac{C_n}{(1+s_n)^n}
+P = \frac{C_1}{1+s_1} + \frac{C_2}{(1+s_2)^2} + \cdots + \frac{C_n}{(1+s_n)^n}
 $$
 
 This is different from using one constant yield for every cash flow.
@@ -376,12 +363,7 @@ $$
 When coupons are annual, we have $m=1$, so the pricing equation is:
 
 $$
-P_n
-= \frac{cF/m}{1+s_1}
-+ \frac{cF/m}{(1+s_2)^2}
-+ \cdots
-+ \frac{cF/m}{(1+s_{n-1})^{n-1}}
-+ \frac{cF/m+R}{(1+s_n)^n}
+P_n = \frac{cF/m}{1+s_1} + \frac{cF/m}{(1+s_2)^2} + \cdots + \frac{cF/m}{(1+s_{n-1})^{n-1}} + \frac{cF/m+R}{(1+s_n)^n}
 $$
 
 Since $s_1,\ldots,s_{n-1}$ are already known, the only unknown is $s_n$.

--- a/NUS/QF1100/summary/Lecture 04.md
+++ b/NUS/QF1100/summary/Lecture 04.md
@@ -1,0 +1,498 @@
+# Lecture 04
+
+This lecture relaxes the earlier assumption that interest rates are
+constant. Instead, interest rates may vary with time to maturity.
+
+Unless stated otherwise, the lecture uses yearly compounding, so rates are
+quoted per year and a maturity of $t$ means $t$ years.
+
+## Variable Definitions
+
+$$
+0 = \text{today, or the present time}
+$$
+
+$$
+t = \text{a future time or maturity, measured in years}
+$$
+
+$$
+j,k = \text{future times with } k>j>0
+$$
+
+$$
+s_t = \text{spot rate for maturity } t
+$$
+
+$$
+s_1,s_2,\ldots,s_n = \text{spot rates for maturities } 1,2,\ldots,n
+$$
+
+$$
+f_{j,k} = \text{forward rate agreed today for the period from time } j \text{ to time } k
+$$
+
+$$
+f_{0,t} = \text{forward rate starting today and ending at time } t,\text{ which equals } s_t
+$$
+
+$$
+C_t = \text{cash flow paid at time } t
+$$
+
+$$
+C_1,C_2,\ldots,C_n = \text{cash flows paid at times } 1,2,\ldots,n
+$$
+
+$$
+\operatorname{PV} = \text{present value}
+$$
+
+$$
+(1+s_t)^t = \text{accumulation factor from time } 0 \text{ to time } t
+$$
+
+$$
+P = \text{price of a bond or present value of a cash flow}
+$$
+
+$$
+R = \text{redemption or face value paid at maturity}
+$$
+
+$$
+n = \text{number of coupon or discounting periods up to maturity}
+$$
+
+$$
+P_n = \text{price of an } n\text{-period coupon-paying bond used in bootstrapping}
+$$
+
+$$
+F = \text{face value of a coupon-paying bond}
+$$
+
+$$
+c = \text{nominal annual coupon rate}
+$$
+
+$$
+m = \text{number of coupon payments per year}
+$$
+
+$$
+\frac{cF}{m} = \text{coupon payment each period for a coupon-paying bond}
+$$
+
+$$
+\frac{cF}{m}+R = \text{final cash flow consisting of the last coupon plus redemption value}
+$$
+
+When payments occur more frequently than once per year, the cash-flow dates
+and spot-rate subscripts are adjusted to the actual times, such as
+$1/m,2/m,\ldots,n/m$.
+
+The term structure of interest rates is the collection of spot rates for
+different maturities, such as:
+
+$$
+\{s_1,s_2,s_3,\ldots\}
+$$
+
+## Spot Rates
+
+A spot rate, or zero rate, is the annual interest rate for money held from
+today, time $0$, until a future time $t$.
+
+The spot rate for maturity $t$ is denoted:
+
+$$
+s_t
+$$
+
+Under the yearly compounding convention used in the lecture, $s_t$ is
+defined so that:
+
+$$
+(1+s_t)^t
+$$
+
+is the accumulation factor for holding money from time $0$ to time $t$.
+
+Equivalently, if a cash flow $C_t$ is paid at time $t$, its present value is:
+
+$$
+\operatorname{PV}
+= \frac{C_t}{(1+s_t)^t}
+$$
+
+The collection of spot rates defines the term structure of interest rates.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The spot rate $s_t$ is the annualized rate implied for maturity $t$.
+
+If one unit of money grows for $t$ years at the spot rate for maturity
+$t$, then under yearly compounding it becomes:
+
+$$
+(1+s_t)^t
+$$
+
+So if a future payment $C_t$ is due at time $t$, the amount today that
+grows to that payment must be:
+
+$$
+\frac{C_t}{(1+s_t)^t}
+$$
+
+This is why spot rates are fundamental: each maturity has its own
+discount rate, rather than forcing all cash flows to use one constant
+yield.
+
+In other words, $s_t$ is not just "the rate at time $t$". It is the rate
+that links values today to values at maturity $t$.
+
+</details>
+
+## Spot Rate from a Zero Coupon Bond
+
+The spot rate is the yield to maturity of a zero coupon bond with that
+maturity.
+
+For an $n$-period zero coupon bond with price $P$ and redemption value
+$R$:
+
+$$
+P = \frac{R}{(1+s_n)^n}
+$$
+
+Solving for $s_n$:
+
+$$
+s_n
+= \left(\frac{R}{P}\right)^{1/n} - 1
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A zero coupon bond is the cleanest possible instrument for finding a spot
+rate because it has only one cash flow.
+
+Its price must equal the present value of the redemption payment:
+
+$$
+P=\frac{R}{(1+s_n)^n}
+$$
+
+Since $P$ and $R$ are known from the bond, the only unknown is $s_n$.
+Rearranging gives:
+
+$$
+(1+s_n)^n = \frac{R}{P}
+$$
+
+and then:
+
+$$
+s_n = \left(\frac{R}{P}\right)^{1/n}-1
+$$
+
+This is why zero coupon bonds "isolate" spot rates directly.
+
+Coupon-paying bonds do not isolate one spot rate so cleanly, because their
+prices mix together cash flows from several dates.
+
+</details>
+
+## Forward Rates
+
+A forward rate is an interest rate agreed today for a future time period.
+
+The forward rate from time $j$ to time $k$, where $k > j > 0$, is
+denoted:
+
+$$
+f_{j,k}
+$$
+
+By convention:
+
+$$
+f_{0,t} = s_t
+$$
+
+So a spot rate can be viewed as a forward rate that starts today.
+
+<details>
+<summary>Intuition / proof</summary>
+
+A spot rate starts now. A forward rate starts later, but the rate is fixed
+today.
+
+So:
+
+- $s_t$ prices borrowing or lending from time $0$ to time $t$.
+- $f_{j,k}$ prices borrowing or lending from time $j$ to time $k$,
+  agreed at time $0$.
+
+The convention
+
+$$
+f_{0,t}=s_t
+$$
+
+simply says a spot rate is a special case of a forward rate whose starting
+date is today.
+
+So forward rates are the building blocks for future sub-periods, while
+spot rates cover the whole period from now to a future date.
+
+</details>
+
+## Spot and Forward Rate Relationship
+
+The key no-arbitrage relationship is:
+
+$$
+(1+s_k)^k
+= (1+s_j)^j(1+f_{j,k})^{k-j}
+$$
+
+for:
+
+$$
+k > j > 0
+$$
+
+Solving for the forward rate:
+
+$$
+f_{j,k}
+=
+\left[
+\frac{(1+s_k)^k}{(1+s_j)^j}
+\right]^{1/(k-j)}
+- 1
+$$
+
+For the one-period forward rate from year $1$ to year $2$:
+
+$$
+(1+s_2)^2 = (1+s_1)(1+f_{1,2})
+$$
+
+Thus:
+
+$$
+f_{1,2}
+= \frac{(1+s_2)^2}{1+s_1} - 1
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The no-arbitrage idea is that two investment strategies with the same
+start date and end date should produce the same accumulated value.
+
+To reach time $k$, you can:
+
+1. invest directly from time $0$ to time $k$ at spot rate $s_k$, or
+2. invest from time $0$ to time $j$ at spot rate $s_j$, then reinvest
+   from time $j$ to time $k$ at forward rate $f_{j,k}$.
+
+Strategy 1 gives:
+
+$$
+(1+s_k)^k
+$$
+
+Strategy 2 gives:
+
+$$
+(1+s_j)^j(1+f_{j,k})^{k-j}
+$$
+
+No arbitrage forces these to be equal, which gives the forward-rate
+formula after rearranging.
+
+To solve explicitly:
+
+$$
+(1+f_{j,k})^{k-j}
+=
+\frac{(1+s_k)^k}{(1+s_j)^j}
+$$
+
+so:
+
+$$
+1+f_{j,k}
+=
+\left[
+\frac{(1+s_k)^k}{(1+s_j)^j}
+\right]^{1/(k-j)}
+$$
+
+and subtracting $1$ gives the forward-rate formula.
+
+</details>
+
+## Pricing Cash Flows with Spot Rates
+
+When spot rates are known, each cash flow is discounted using the spot
+rate matching its payment time.
+
+For cash flows $C_1,C_2,\ldots,C_n$:
+
+$$
+P
+= \frac{C_1}{1+s_1}
++ \frac{C_2}{(1+s_2)^2}
++ \cdots
++ \frac{C_n}{(1+s_n)^n}
+$$
+
+This is different from using one constant yield for every cash flow.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Each cash flow has its own maturity, so each cash flow should use the
+spot rate for that maturity.
+
+The payment at time $1$ is discounted by $s_1$, the payment at time $2$
+is discounted by $s_2$, and so on:
+
+$$
+\frac{C_1}{1+s_1},\quad
+\frac{C_2}{(1+s_2)^2},\quad
+\ldots,\quad
+\frac{C_n}{(1+s_n)^n}
+$$
+
+Then the total price is the sum of these present values.
+
+This is more accurate than discounting every payment at one constant yield
+when the market term structure is not flat.
+
+The law of one price is the reason this works: the price of the whole cash
+flow stream must equal the sum of the prices of its pieces.
+
+</details>
+
+## Bootstrap Method
+
+Prices of zero coupon bonds for every maturity may not be available.
+When that happens, spot rates can be solved from coupon-paying bonds
+using the bootstrap method.
+
+The bootstrap method solves spot rates one maturity at a time.
+
+Suppose:
+
+$$
+s_1,s_2,\ldots,s_{n-1}
+$$
+
+have already been determined. For the yearly-coupon case, consider an
+$n$-period coupon-paying bond with price $P_n$ and cash flows:
+
+$$
+(-P_n,\ cF/m,\ cF/m,\ \ldots,\ cF/m + R)
+$$
+
+When coupons are annual, we have $m=1$, so the pricing equation is:
+
+$$
+P_n
+= \frac{cF/m}{1+s_1}
++ \frac{cF/m}{(1+s_2)^2}
++ \cdots
++ \frac{cF/m}{(1+s_{n-1})^{n-1}}
++ \frac{cF/m+R}{(1+s_n)^n}
+$$
+
+Since $s_1,\ldots,s_{n-1}$ are already known, the only unknown is $s_n$.
+So $s_n$ can be solved from the equation.
+
+This is why earlier spot rates must be determined first: later
+coupon-paying bonds include earlier cash flows that must be discounted
+using the already-known spot rates.
+
+If coupons occur more frequently than once per year, the same idea still
+works, but the matching payment dates must be used. For example, with
+coupon frequency $m$, the payment times are:
+
+$$
+\frac{1}{m},\frac{2}{m},\ldots,\frac{n}{m}
+$$
+
+so the corresponding spot rates are:
+
+$$
+s_{1/m},s_{2/m},\ldots,s_{n/m}.
+$$
+
+In that general case, each cash flow must be discounted using the spot
+rate matching its actual payment date.
+
+### Bootstrap Procedure
+
+1. Use a 1-period bond to find $s_1$.
+2. Use a 2-period bond and the known $s_1$ to find $s_2$.
+3. Use a 3-period bond and the known $s_1,s_2$ to find $s_3$.
+4. Continue until the required spot rates are found.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Bootstrapping works because once the earlier spot rates are known, the
+earlier coupon cash flows of a later bond can already be priced.
+
+In the $n$-period bond formula, all terms except the last one involve
+spot rates that were solved earlier:
+
+$$
+s_1,s_2,\ldots,s_{n-1}
+$$
+
+So after subtracting the present value of the earlier coupon payments from
+the bond price, the remaining unknown part is the final term involving
+$s_n$.
+
+That is why the method must proceed sequentially: first $s_1$, then
+$s_2$, then $s_3$, and so on.
+
+More explicitly, once the earlier terms are moved to the left-hand side,
+we get:
+
+$$
+P_n
+- \frac{cF/m}{1+s_1}
+- \frac{cF/m}{(1+s_2)^2}
+- \cdots
+- \frac{cF/m}{(1+s_{n-1})^{n-1}}
+=
+\frac{cF/m+R}{(1+s_n)^n}
+$$
+
+and now the only unknown in the equation is $s_n$.
+
+If coupons are more frequent than annual, the same rearrangement works,
+but the terms must use the matching dates
+$\frac{1}{m},\frac{2}{m},\ldots,\frac{n}{m}$ rather than the annual dates
+$1,2,\ldots,n$.
+
+</details>
+
+## Key Takeaways
+
+- A spot rate $s_t$ is the rate from today to time $t$.
+- A forward rate $f_{j,k}$ is the rate from future time $j$ to future time $k$, agreed today.
+- Spot and forward rates are connected by a no-arbitrage relationship.
+- Each cash flow should be discounted using the spot rate matching its payment time.
+- Zero coupon bonds isolate spot rates directly because they have only one cash flow.
+- Bootstrapping solves spot rates sequentially: first $s_1$, then $s_2$, then $s_3$, and so on.

--- a/NUS/QF1100/summary/Lecture 04.md
+++ b/NUS/QF1100/summary/Lecture 04.md
@@ -255,7 +255,7 @@ $$
 Solving for the forward rate:
 
 $$
-f_{j,k} = \left[ \frac{(1+s_k)^k}{(1+s_j)^j} \right]^{1/(k-j)} - 1
+f_{j,k} = \left( \frac{(1+s_k)^k}{(1+s_j)^j} \right)^{1/(k-j)} - 1
 $$
 
 For the one-period forward rate from year $1$ to year $2$:

--- a/NUS/QF1100/summary/Lecture 05.md
+++ b/NUS/QF1100/summary/Lecture 05.md
@@ -362,7 +362,7 @@ positive, so the weighted average itself must be positive.
 If $X$ has mean $E(X)$, then the variance of $X$ is:
 
 $$
-\mathrm{Var}(X) = E\left[(X-E(X))^2\right]
+\mathrm{Var}(X) = E\left((X-E(X))^2\right)
 $$
 
 Variance is the expected squared deviation from the mean.
@@ -426,7 +426,7 @@ and $Y$.
 It is defined by:
 
 $$
-\mathrm{Cov}(X,Y) = E\left[(X-E(X))(Y-E(Y))\right]
+\mathrm{Cov}(X,Y) = E\left((X-E(X))(Y-E(Y))\right)
 $$
 
 It can also be written as:

--- a/NUS/QF1100/summary/Lecture 05.md
+++ b/NUS/QF1100/summary/Lecture 05.md
@@ -1,0 +1,669 @@
+# Lecture 05
+
+This lecture moves from fixed-income securities to investments whose
+future value is uncertain.
+
+Returns are therefore studied using probability and random variables.
+
+## Variable Definitions
+
+$$
+t = \text{time}
+$$
+
+$$
+\Omega = \text{sample space of the random experiment}
+$$
+
+$$
+\omega = \text{an outcome in the sample space}
+$$
+
+$$
+P_0 = \text{price of the asset at time } 0
+$$
+
+$$
+P_1 = \text{price of the asset at time } 1
+$$
+
+$$
+R = \text{total return}
+$$
+
+$$
+r = \text{rate of return}
+$$
+
+$$
+X,Y,Z = \text{random variables}
+$$
+
+$$
+x,y = \text{possible values taken by random variables}
+$$
+
+$$
+p(x) = P(X=x) = \text{probability mass function of } X
+$$
+
+$$
+p(x,y) = P(X=x,Y=y) = \text{joint probability mass function of } X \text{ and } Y
+$$
+
+$$
+P(X=x),\ P(X=x,Y=y) = \text{probabilities of single or joint events}
+$$
+
+$$
+E(X) = \text{expected value, or mean, of } X
+$$
+
+$$
+\mu = E(X) = \text{mean of } X
+$$
+
+$$
+\operatorname{Var}(X) = \text{variance of } X
+$$
+
+$$
+\operatorname{SD}(X) = \text{standard deviation of } X
+$$
+
+$$
+\sigma^2,\sigma_X^2 = \text{common notation for } \operatorname{Var}(X)
+$$
+
+$$
+\sigma,\sigma_X = \text{common notation for } \operatorname{SD}(X)
+$$
+
+$$
+\operatorname{Cov}(X,Y) = \text{covariance of } X \text{ and } Y
+$$
+
+$$
+\rho_{X,Y} = \operatorname{Corr}(X,Y) = \text{correlation coefficient of } X \text{ and } Y
+$$
+
+$$
+a,b,c = \text{constants}
+$$
+
+## Assets
+
+An investment instrument that can be bought and sold is called an asset.
+
+Suppose an investor buys an asset at time $t=0$ for price $P_0$ and sells
+it at time $t=1$ for price $P_1$.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The lecture uses a simple one-period investment horizon:
+
+- buy at time $0$
+- sell at time $1$
+
+This is enough to define return. More complicated settings build on the
+same idea period by period.
+</details>
+
+## Returns
+
+The total return is defined as:
+
+$$
+R = \frac{\text{amount received}}{\text{amount invested}}
+= \frac{P_1}{P_0}
+$$
+
+The rate of return is defined as:
+
+$$
+r
+= \frac{\text{amount received} - \text{amount invested}}
+{\text{amount invested}}
+= \frac{P_1 - P_0}{P_0}
+$$
+
+The two are related by:
+
+$$
+R = 1 + r
+$$
+
+Hence:
+
+$$
+P_1 = (1+r)P_0
+$$
+
+So a rate of return behaves like an interest rate over a single period.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Total return tells us the multiplicative growth factor of the investment:
+
+$$
+R=\frac{P_1}{P_0}
+$$
+
+Rate of return tells us the gain relative to the initial investment:
+
+$$
+r=\frac{P_1-P_0}{P_0}
+$$
+
+Since
+
+$$
+\frac{P_1}{P_0}
+=
+\frac{P_0+(P_1-P_0)}{P_0}
+=
+1+\frac{P_1-P_0}{P_0},
+$$
+
+we get:
+
+$$
+R=1+r
+$$
+
+Rearranging gives:
+
+$$
+P_1=(1+r)P_0,
+$$
+
+which is why a one-period return acts like a one-period interest rate.
+</details>
+
+## Short Sales
+
+Short-selling means selling an asset that the investor does not currently
+own.
+
+The mechanics are:
+
+1. Borrow the asset from someone who owns it.
+2. Sell the borrowed asset and receive $P_0$.
+3. Later, buy it back for $P_1$ and return it to the lender.
+
+Dollar profit from a short sale:
+
+$$
+\text{profit} = P_0 - P_1
+$$
+
+So a profit is made when:
+
+$$
+P_1 < P_0
+$$
+
+The lecture notes that short-selling is risky because the potential loss is
+unlimited: the asset price can rise without bound.
+
+For short sales, using the lecture's sign convention for total return:
+
+$$
+R = \frac{-P_1}{-P_0} = \frac{P_1}{P_0}
+$$
+
+Under this convention, the short-sale dollar profit is still measured by
+$P_0-P_1$. So unlike a long position, a profitable short sale has
+$R<1$ and $r<0$.
+
+<details>
+<summary>Intuition / proof</summary>
+
+In a short sale, you benefit when the asset price falls.
+
+You first receive $P_0$ from selling the borrowed asset, then later pay
+$P_1$ to buy it back. So the dollar profit is:
+
+$$
+P_0-P_1
+$$
+
+That is positive exactly when:
+
+$$
+P_1<P_0
+$$
+
+The "return on short sale" formula can look strange because the lecture
+treats the initial and final cash flows using negative signs:
+
+$$
+R=\frac{-P_1}{-P_0}=\frac{P_1}{P_0}
+$$
+
+So this return convention does not track profit direction in the same
+intuitive way as a long position. A profitable short sale has a positive
+dollar profit $P_0-P_1$, but it corresponds to $R<1$ and $r<0$.
+
+The key danger is that if the asset price rises a lot, then the cost of
+buying it back can become arbitrarily large, so losses are not capped.
+</details>
+
+## Returns as Random Variables
+
+If the future selling price $P_1$ is uncertain, then the return is random.
+So returns can be studied using probability.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Once $P_1$ is unknown, formulas such as
+
+$$
+R=\frac{P_1}{P_0},
+\qquad
+r=\frac{P_1-P_0}{P_0}
+$$
+
+become random as well. That is why return analysis naturally leads into
+random variables, probability, expectation, and variance.
+</details>
+
+## Random Variable
+
+A random variable is a function that assigns a real number to each
+outcome in the sample space of a random experiment.
+
+<details>
+<summary>Intuition / proof</summary>
+
+A random experiment produces an outcome $\omega \in \Omega$.
+
+A random variable $X$ then converts that outcome into a number:
+
+$$
+X(\omega)
+$$
+
+This lets us describe uncertain quantities numerically, which is why
+random variables are the bridge from probability to finance.
+</details>
+
+## Discrete Random Variable
+
+A random variable is discrete if its possible values are finite or
+countably infinite.
+
+If $X$ is a discrete random variable and $x$ is one of its possible values,
+its probability mass function, or pmf, is:
+
+$$
+p(x) = P(X=x)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A random variable turns uncertain outcomes into numbers that we can work
+with mathematically.
+
+In the discrete case, we can list the possible values and assign a
+probability to each one. That is exactly what the pmf does:
+
+$$
+p(x)=P(X=x)
+$$
+
+So the pmf is the basic input used to compute expectations, variances, and
+other summaries.
+</details>
+
+## Expected Value
+
+If $X$ is a discrete random variable with pmf $p(x)$, then its expected
+value is:
+
+$$
+E(X) = \sum_x x\,p(x)
+$$
+
+where the sum is over all possible values of $x$.
+
+The expected value is also called the mean, and is often denoted by:
+
+$$
+\mu = E(X)
+$$
+
+### Basic Properties of Expectation
+
+$$
+E(c) = c
+$$
+
+$$
+E(cX) = cE(X)
+$$
+
+$$
+E(X+c) = E(X) + c
+$$
+
+$$
+E(aX+bY) = aE(X) + bE(Y)
+$$
+
+If:
+
+$$
+X > 0
+$$
+
+then:
+
+$$
+E(X) > 0
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The expected value is a probability-weighted average:
+
+$$
+E(X)=\sum_x x\,p(x)
+$$
+
+It describes the center of the distribution, or the long-run average if
+the experiment were repeated many times.
+
+The expectation rules come from distributing sums and constants through
+the weighted average. For example:
+
+$$
+E(aX+bY)=aE(X)+bE(Y)
+$$
+
+because expectation is linear.
+
+The sign-preserving property also makes sense intuitively: if $X$ is always
+positive, then every value contributing to the weighted average is
+positive, so the weighted average itself must be positive.
+</details>
+
+## Variance
+
+If $X$ has mean $E(X)$, then the variance of $X$ is:
+
+$$
+\operatorname{Var}(X)
+= E\left[(X-E(X))^2\right]
+$$
+
+Variance is the expected squared deviation from the mean.
+
+Common notation:
+
+$$
+\sigma^2, \qquad \sigma_X^2
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Variance measures spread around the mean.
+
+The deviation from the mean is:
+
+$$
+X-E(X)
+$$
+
+Squaring removes sign and emphasizes larger deviations:
+
+$$
+(X-E(X))^2
+$$
+
+Taking expectation gives the average squared distance from the mean:
+
+$$
+\operatorname{Var}(X)=E\left[(X-E(X))^2\right]
+$$
+</details>
+
+## Standard Deviation
+
+The standard deviation of $X$ is the square root of its variance:
+
+$$
+\operatorname{SD}(X) = \sqrt{\operatorname{Var}(X)}
+$$
+
+Common notation:
+
+$$
+\sigma, \qquad \sigma_X
+$$
+
+The standard deviation has the same units as $X$.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Variance is useful mathematically, but it is measured in squared units.
+Standard deviation fixes that by taking the square root:
+
+$$
+\operatorname{SD}(X)=\sqrt{\operatorname{Var}(X)}
+$$
+
+So it measures spread in the same units as the original random variable.
+</details>
+
+## Covariance
+
+Covariance measures linear dependence between two random variables $X$
+and $Y$.
+
+It is defined by:
+
+$$
+\operatorname{Cov}(X,Y)
+= E\left[(X-E(X))(Y-E(Y))\right]
+$$
+
+It can also be written as:
+
+$$
+\operatorname{Cov}(X,Y)
+= E(XY) - E(X)E(Y)
+$$
+
+In general:
+
+$$
+E(XY) \ne E(X)E(Y)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Covariance checks whether $X$ and $Y$ tend to move together relative to
+their means.
+
+- If both are above their means together, the product
+  $(X-E(X))(Y-E(Y))$ is positive.
+- If one is above its mean while the other is below, the product is
+  negative.
+
+So:
+
+$$
+\operatorname{Cov}(X,Y)
+=E\left[(X-E(X))(Y-E(Y))\right]
+$$
+
+is positive for positive linear association and negative for negative
+linear association.
+
+Expanding the product gives the equivalent formula:
+
+$$
+\operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)
+$$
+</details>
+
+## Correlation Coefficient
+
+The correlation coefficient of $X$ and $Y$ is:
+
+$$
+\rho_{X,Y}
+= \operatorname{Corr}(X,Y)
+= \frac{\operatorname{Cov}(X,Y)}
+{\operatorname{SD}(X)\operatorname{SD}(Y)}
+$$
+
+It rescales covariance to remove the units of $X$ and $Y$.
+
+When $\operatorname{SD}(X)$ and $\operatorname{SD}(Y)$ are both nonzero,
+its range is:
+
+$$
+-1 \le \rho_{X,Y} \le 1
+$$
+
+Interpretation:
+
+- $\rho_{X,Y}$ near $+1$ means strong positive linear relationship.
+- $\rho_{X,Y}$ near $-1$ means strong negative linear relationship.
+- $\rho_{X,Y}$ near $0$ means little or no linear relationship.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Covariance depends on the units of $X$ and $Y$, so its size is hard to
+compare across problems.
+
+Correlation removes the scale by dividing by the standard deviations:
+
+$$
+\rho_{X,Y}
+=\frac{\operatorname{Cov}(X,Y)}
+{\operatorname{SD}(X)\operatorname{SD}(Y)}
+$$
+
+That is why correlation is unit-free and, when defined, always lies between
+$-1$ and $1$.
+
+The closer $\rho_{X,Y}$ is to $\pm 1$, the stronger the linear
+relationship.
+
+In effect, correlation is a normalized covariance: it keeps the direction
+of association while removing the scale effect.
+</details>
+
+## Independence
+
+Two jointly discrete random variables $X$ and $Y$ are independent if:
+
+$$
+P(X=x,Y=y) = P(X=x)P(Y=y)
+$$
+
+for all $x$ and $y$.
+
+Important relationship:
+
+- If $X$ and $Y$ are independent, then $\operatorname{Cov}(X,Y)=0$. If $\operatorname{SD}(X)$ and $\operatorname{SD}(Y)$ are both nonzero, then $\rho_{X,Y}=0$.
+- But $\rho_{X,Y}=0$ does not imply independence in general.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Independence means knowing the value of one random variable gives no
+information about the other.
+
+For discrete random variables, that is expressed by the factorization:
+
+$$
+P(X=x,Y=y)=P(X=x)P(Y=y)
+$$
+
+Independence implies zero covariance, but the converse fails in general:
+two variables can have no linear relationship while still being dependent
+in a nonlinear way.
+
+The reason independence implies zero covariance is that independence gives
+
+$$
+E(XY)=E(X)E(Y),
+$$
+
+so:
+
+$$
+\operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)=0.
+$$
+</details>
+
+## Properties of Covariance and Variance
+
+For constants $a,b$ and random variables $X,Y,Z$:
+
+$$
+\operatorname{Cov}(X,Y) = \operatorname{Cov}(Y,X)
+$$
+
+$$
+\operatorname{Cov}(X,X) = \operatorname{Var}(X)
+$$
+
+$$
+\operatorname{Cov}(aX+bY,Z)
+= a\operatorname{Cov}(X,Z) + b\operatorname{Cov}(Y,Z)
+$$
+
+For two random variables $X$ and $Y$:
+
+$$
+\operatorname{Var}(X+Y)
+= \operatorname{Var}(X) + 2\operatorname{Cov}(X,Y) + \operatorname{Var}(Y)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+These formulas show how covariance and variance behave under algebraic
+combinations.
+
+The most important one here is:
+
+$$
+\operatorname{Var}(X+Y)
+= \operatorname{Var}(X) + 2\operatorname{Cov}(X,Y) + \operatorname{Var}(Y)
+$$
+
+It comes from expanding:
+
+$$
+\operatorname{Var}(X+Y)
+= E\left[(X+Y-E(X)-E(Y))^2\right]
+$$
+
+The cross term appears twice, which is why the covariance coefficient is
+$2$, not $1$.
+</details>
+
+## Key Takeaways
+
+- $R$ is total return and $r$ is rate of return.
+- $R = 1+r$ and $P_1=(1+r)P_0$.
+- For a short sale, profit is made when the asset price falls.
+- When returns are uncertain, they are treated as random variables.
+- Expectation measures center, while variance and standard deviation measure spread.
+- Covariance and correlation describe how two random variables move together.
+- Independence implies zero covariance, but zero covariance does not imply independence in general.

--- a/NUS/QF1100/summary/Lecture 05.md
+++ b/NUS/QF1100/summary/Lecture 05.md
@@ -147,37 +147,23 @@ So a rate of return behaves like an interest rate over a single period.
 
 Total return tells us the multiplicative growth factor of the investment:
 
-$$
-R=\frac{P_1}{P_0}
-$$
+$\displaystyle R=\frac{P_1}{P_0}$
 
 Rate of return tells us the gain relative to the initial investment:
 
-$$
-r=\frac{P_1-P_0}{P_0}
-$$
+$\displaystyle r=\frac{P_1-P_0}{P_0}$
 
 Since
 
-$$
-\frac{P_1}{P_0}
-=
-\frac{P_0+(P_1-P_0)}{P_0}
-=
-1+\frac{P_1-P_0}{P_0},
-$$
+$\displaystyle \frac{P_1}{P_0} = \frac{P_0+(P_1-P_0)}{P_0} = 1+\frac{P_1-P_0}{P_0},$
 
 we get:
 
-$$
-R=1+r
-$$
+$\displaystyle R=1+r$
 
 Rearranging gives:
 
-$$
-P_1=(1+r)P_0,
-$$
+$\displaystyle P_1=(1+r)P_0,$
 
 which is why a one-period return acts like a one-period interest rate.
 </details>
@@ -226,22 +212,16 @@ In a short sale, you benefit when the asset price falls.
 You first receive $P_0$ from selling the borrowed asset, then later pay
 $P_1$ to buy it back. So the dollar profit is:
 
-$$
-P_0-P_1
-$$
+$\displaystyle P_0-P_1$
 
 That is positive exactly when:
 
-$$
-P_1<P_0
-$$
+$\displaystyle P_1<P_0$
 
 The "return on short sale" formula can look strange because the lecture
 treats the initial and final cash flows using negative signs:
 
-$$
-R=\frac{-P_1}{-P_0}=\frac{P_1}{P_0}
-$$
+$\displaystyle R=\frac{-P_1}{-P_0}=\frac{P_1}{P_0}$
 
 So this return convention does not track profit direction in the same
 intuitive way as a long position. A profitable short sale has a positive
@@ -261,11 +241,7 @@ So returns can be studied using probability.
 
 Once $P_1$ is unknown, formulas such as
 
-$$
-R=\frac{P_1}{P_0},
-\qquad
-r=\frac{P_1-P_0}{P_0}
-$$
+$\displaystyle R=\frac{P_1}{P_0}, \qquad r=\frac{P_1-P_0}{P_0}$
 
 become random as well. That is why return analysis naturally leads into
 random variables, probability, expectation, and variance.
@@ -283,9 +259,7 @@ A random experiment produces an outcome $\omega \in \Omega$.
 
 A random variable $X$ then converts that outcome into a number:
 
-$$
-X(\omega)
-$$
+$\displaystyle X(\omega)$
 
 This lets us describe uncertain quantities numerically, which is why
 random variables are the bridge from probability to finance.
@@ -312,9 +286,7 @@ with mathematically.
 In the discrete case, we can list the possible values and assign a
 probability to each one. That is exactly what the pmf does:
 
-$$
-p(x)=P(X=x)
-$$
+$\displaystyle p(x)=P(X=x)$
 
 So the pmf is the basic input used to compute expectations, variances, and
 other summaries.
@@ -372,9 +344,7 @@ $$
 
 The expected value is a probability-weighted average:
 
-$$
-E(X)=\sum_x x\,p(x)
-$$
+$\displaystyle E(X)=\sum_x x\,p(x)$
 
 It describes the center of the distribution, or the long-run average if
 the experiment were repeated many times.
@@ -382,9 +352,7 @@ the experiment were repeated many times.
 The expectation rules come from distributing sums and constants through
 the weighted average. For example:
 
-$$
-E(aX+bY)=aE(X)+bE(Y)
-$$
+$\displaystyle E(aX+bY)=aE(X)+bE(Y)$
 
 because expectation is linear.
 
@@ -417,21 +385,15 @@ Variance measures spread around the mean.
 
 The deviation from the mean is:
 
-$$
-X-E(X)
-$$
+$\displaystyle X-E(X)$
 
 Squaring removes sign and emphasizes larger deviations:
 
-$$
-(X-E(X))^2
-$$
+$\displaystyle (X-E(X))^2$
 
 Taking expectation gives the average squared distance from the mean:
 
-$$
-\operatorname{Var}(X)=E\left[(X-E(X))^2\right]
-$$
+$\displaystyle \operatorname{Var}(X)=E\left[(X-E(X))^2\right]$
 </details>
 
 ## Standard Deviation
@@ -456,9 +418,7 @@ The standard deviation has the same units as $X$.
 Variance is useful mathematically, but it is measured in squared units.
 Standard deviation fixes that by taking the square root:
 
-$$
-\operatorname{SD}(X)=\sqrt{\operatorname{Var}(X)}
-$$
+$\displaystyle \operatorname{SD}(X)=\sqrt{\operatorname{Var}(X)}$
 
 So it measures spread in the same units as the original random variable.
 </details>
@@ -501,19 +461,14 @@ their means.
 
 So:
 
-$$
-\operatorname{Cov}(X,Y)
-=E\left[(X-E(X))(Y-E(Y))\right]
-$$
+$\displaystyle \operatorname{Cov}(X,Y) =E\left[(X-E(X))(Y-E(Y))\right]$
 
 is positive for positive linear association and negative for negative
 linear association.
 
 Expanding the product gives the equivalent formula:
 
-$$
-\operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)
-$$
+$\displaystyle \operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)$
 </details>
 
 ## Correlation Coefficient
@@ -550,11 +505,7 @@ compare across problems.
 
 Correlation removes the scale by dividing by the standard deviations:
 
-$$
-\rho_{X,Y}
-=\frac{\operatorname{Cov}(X,Y)}
-{\operatorname{SD}(X)\operatorname{SD}(Y)}
-$$
+$\displaystyle \rho_{X,Y} =\frac{\operatorname{Cov}(X,Y)} {\operatorname{SD}(X)\operatorname{SD}(Y)}$
 
 That is why correlation is unit-free and, when defined, always lies between
 $-1$ and $1$.
@@ -589,9 +540,7 @@ information about the other.
 
 For discrete random variables, that is expressed by the factorization:
 
-$$
-P(X=x,Y=y)=P(X=x)P(Y=y)
-$$
+$\displaystyle P(X=x,Y=y)=P(X=x)P(Y=y)$
 
 Independence implies zero covariance, but the converse fails in general:
 two variables can have no linear relationship while still being dependent
@@ -599,15 +548,11 @@ in a nonlinear way.
 
 The reason independence implies zero covariance is that independence gives
 
-$$
-E(XY)=E(X)E(Y),
-$$
+$\displaystyle E(XY)=E(X)E(Y),$
 
 so:
 
-$$
-\operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)=0.
-$$
+$\displaystyle \operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)=0.$
 </details>
 
 ## Properties of Covariance and Variance
@@ -642,17 +587,11 @@ combinations.
 
 The most important one here is:
 
-$$
-\operatorname{Var}(X+Y)
-= \operatorname{Var}(X) + 2\operatorname{Cov}(X,Y) + \operatorname{Var}(Y)
-$$
+$\displaystyle \operatorname{Var}(X+Y) = \operatorname{Var}(X) + 2\operatorname{Cov}(X,Y) + \operatorname{Var}(Y)$
 
 It comes from expanding:
 
-$$
-\operatorname{Var}(X+Y)
-= E\left[(X+Y-E(X)-E(Y))^2\right]
-$$
+$\displaystyle \operatorname{Var}(X+Y) = E\left[(X+Y-E(X)-E(Y))^2\right]$
 
 The cross term appears twice, which is why the covariance coefficient is
 $2$, not $1$.

--- a/NUS/QF1100/summary/Lecture 05.md
+++ b/NUS/QF1100/summary/Lecture 05.md
@@ -147,23 +147,23 @@ So a rate of return behaves like an interest rate over a single period.
 
 Total return tells us the multiplicative growth factor of the investment:
 
-$\displaystyle R=\frac{P_1}{P_0}$
+$R=\frac{P_1}{P_0}$
 
 Rate of return tells us the gain relative to the initial investment:
 
-$\displaystyle r=\frac{P_1-P_0}{P_0}$
+$r=\frac{P_1-P_0}{P_0}$
 
 Since
 
-$\displaystyle \frac{P_1}{P_0} = \frac{P_0+(P_1-P_0)}{P_0} = 1+\frac{P_1-P_0}{P_0},$
+$\frac{P_1}{P_0} = \frac{P_0+(P_1-P_0)}{P_0} = 1+\frac{P_1-P_0}{P_0},$
 
 we get:
 
-$\displaystyle R=1+r$
+$R=1+r$
 
 Rearranging gives:
 
-$\displaystyle P_1=(1+r)P_0,$
+$P_1=(1+r)P_0,$
 
 which is why a one-period return acts like a one-period interest rate.
 </details>
@@ -212,16 +212,16 @@ In a short sale, you benefit when the asset price falls.
 You first receive $P_0$ from selling the borrowed asset, then later pay
 $P_1$ to buy it back. So the dollar profit is:
 
-$\displaystyle P_0-P_1$
+$P_0-P_1$
 
 That is positive exactly when:
 
-$\displaystyle P_1<P_0$
+$P_1<P_0$
 
 The "return on short sale" formula can look strange because the lecture
 treats the initial and final cash flows using negative signs:
 
-$\displaystyle R=\frac{-P_1}{-P_0}=\frac{P_1}{P_0}$
+$R=\frac{-P_1}{-P_0}=\frac{P_1}{P_0}$
 
 So this return convention does not track profit direction in the same
 intuitive way as a long position. A profitable short sale has a positive
@@ -241,7 +241,7 @@ So returns can be studied using probability.
 
 Once $P_1$ is unknown, formulas such as
 
-$\displaystyle R=\frac{P_1}{P_0}, \qquad r=\frac{P_1-P_0}{P_0}$
+$R=\frac{P_1}{P_0}$ and $r=\frac{P_1-P_0}{P_0}$
 
 become random as well. That is why return analysis naturally leads into
 random variables, probability, expectation, and variance.
@@ -259,7 +259,7 @@ A random experiment produces an outcome $\omega \in \Omega$.
 
 A random variable $X$ then converts that outcome into a number:
 
-$\displaystyle X(\omega)$
+$X(\omega)$
 
 This lets us describe uncertain quantities numerically, which is why
 random variables are the bridge from probability to finance.
@@ -286,7 +286,7 @@ with mathematically.
 In the discrete case, we can list the possible values and assign a
 probability to each one. That is exactly what the pmf does:
 
-$\displaystyle p(x)=P(X=x)$
+$p(x)=P(X=x)$
 
 So the pmf is the basic input used to compute expectations, variances, and
 other summaries.
@@ -344,7 +344,7 @@ $$
 
 The expected value is a probability-weighted average:
 
-$\displaystyle E(X)=\sum_x x\,p(x)$
+$E(X)=\sum_x x\,p(x)$
 
 It describes the center of the distribution, or the long-run average if
 the experiment were repeated many times.
@@ -352,7 +352,7 @@ the experiment were repeated many times.
 The expectation rules come from distributing sums and constants through
 the weighted average. For example:
 
-$\displaystyle E(aX+bY)=aE(X)+bE(Y)$
+$E(aX+bY)=aE(X)+bE(Y)$
 
 because expectation is linear.
 
@@ -385,15 +385,15 @@ Variance measures spread around the mean.
 
 The deviation from the mean is:
 
-$\displaystyle X-E(X)$
+$X-E(X)$
 
 Squaring removes sign and emphasizes larger deviations:
 
-$\displaystyle (X-E(X))^2$
+$(X-E(X))^2$
 
 Taking expectation gives the average squared distance from the mean:
 
-$\displaystyle \operatorname{Var}(X)=E\left[(X-E(X))^2\right]$
+$\mathrm{Var}(X)=E[(X-E(X))^2]$
 </details>
 
 ## Standard Deviation
@@ -418,7 +418,7 @@ The standard deviation has the same units as $X$.
 Variance is useful mathematically, but it is measured in squared units.
 Standard deviation fixes that by taking the square root:
 
-$\displaystyle \operatorname{SD}(X)=\sqrt{\operatorname{Var}(X)}$
+$\mathrm{SD}(X)=\sqrt{\mathrm{Var}(X)}$
 
 So it measures spread in the same units as the original random variable.
 </details>
@@ -461,14 +461,14 @@ their means.
 
 So:
 
-$\displaystyle \operatorname{Cov}(X,Y) =E\left[(X-E(X))(Y-E(Y))\right]$
+$\mathrm{Cov}(X,Y) =E[(X-E(X))(Y-E(Y))]$
 
 is positive for positive linear association and negative for negative
 linear association.
 
 Expanding the product gives the equivalent formula:
 
-$\displaystyle \operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)$
+$\mathrm{Cov}(X,Y)=E(XY)-E(X)E(Y)$
 </details>
 
 ## Correlation Coefficient
@@ -505,7 +505,7 @@ compare across problems.
 
 Correlation removes the scale by dividing by the standard deviations:
 
-$\displaystyle \rho_{X,Y} =\frac{\operatorname{Cov}(X,Y)} {\operatorname{SD}(X)\operatorname{SD}(Y)}$
+$\rho_{X,Y} =\frac{\mathrm{Cov}(X,Y)} {\mathrm{SD}(X)\mathrm{SD}(Y)}$
 
 That is why correlation is unit-free and, when defined, always lies between
 $-1$ and $1$.
@@ -540,7 +540,7 @@ information about the other.
 
 For discrete random variables, that is expressed by the factorization:
 
-$\displaystyle P(X=x,Y=y)=P(X=x)P(Y=y)$
+$P(X=x,Y=y)=P(X=x)P(Y=y)$
 
 Independence implies zero covariance, but the converse fails in general:
 two variables can have no linear relationship while still being dependent
@@ -548,11 +548,11 @@ in a nonlinear way.
 
 The reason independence implies zero covariance is that independence gives
 
-$\displaystyle E(XY)=E(X)E(Y),$
+$E(XY)=E(X)E(Y),$
 
 so:
 
-$\displaystyle \operatorname{Cov}(X,Y)=E(XY)-E(X)E(Y)=0.$
+$\mathrm{Cov}(X,Y)=E(XY)-E(X)E(Y)=0.$
 </details>
 
 ## Properties of Covariance and Variance
@@ -587,11 +587,11 @@ combinations.
 
 The most important one here is:
 
-$\displaystyle \operatorname{Var}(X+Y) = \operatorname{Var}(X) + 2\operatorname{Cov}(X,Y) + \operatorname{Var}(Y)$
+$\mathrm{Var}(X+Y) = \mathrm{Var}(X) + 2\mathrm{Cov}(X,Y) + \mathrm{Var}(Y)$
 
 It comes from expanding:
 
-$\displaystyle \operatorname{Var}(X+Y) = E\left[(X+Y-E(X)-E(Y))^2\right]$
+$\mathrm{Var}(X+Y) = E[(X+Y-E(X)-E(Y))^2]$
 
 The cross term appears twice, which is why the covariance coefficient is
 $2$, not $1$.

--- a/NUS/QF1100/summary/Lecture 05.md
+++ b/NUS/QF1100/summary/Lecture 05.md
@@ -64,27 +64,27 @@ $$
 $$
 
 $$
-\operatorname{Var}(X) = \text{variance of } X
+\mathrm{Var}(X) = \text{variance of } X
 $$
 
 $$
-\operatorname{SD}(X) = \text{standard deviation of } X
+\mathrm{SD}(X) = \text{standard deviation of } X
 $$
 
 $$
-\sigma^2,\sigma_X^2 = \text{common notation for } \operatorname{Var}(X)
+\sigma^2,\sigma_X^2 = \text{common notation for } \mathrm{Var}(X)
 $$
 
 $$
-\sigma,\sigma_X = \text{common notation for } \operatorname{SD}(X)
+\sigma,\sigma_X = \text{common notation for } \mathrm{SD}(X)
 $$
 
 $$
-\operatorname{Cov}(X,Y) = \text{covariance of } X \text{ and } Y
+\mathrm{Cov}(X,Y) = \text{covariance of } X \text{ and } Y
 $$
 
 $$
-\rho_{X,Y} = \operatorname{Corr}(X,Y) = \text{correlation coefficient of } X \text{ and } Y
+\rho_{X,Y} = \mathrm{Corr}(X,Y) = \text{correlation coefficient of } X \text{ and } Y
 $$
 
 $$
@@ -115,17 +115,13 @@ same idea period by period.
 The total return is defined as:
 
 $$
-R = \frac{\text{amount received}}{\text{amount invested}}
-= \frac{P_1}{P_0}
+R = \frac{\text{amount received}}{\text{amount invested}} = \frac{P_1}{P_0}
 $$
 
 The rate of return is defined as:
 
 $$
-r
-= \frac{\text{amount received} - \text{amount invested}}
-{\text{amount invested}}
-= \frac{P_1 - P_0}{P_0}
+r = \frac{\text{amount received} - \text{amount invested}} {\text{amount invested}} = \frac{P_1 - P_0}{P_0}
 $$
 
 The two are related by:
@@ -366,8 +362,7 @@ positive, so the weighted average itself must be positive.
 If $X$ has mean $E(X)$, then the variance of $X$ is:
 
 $$
-\operatorname{Var}(X)
-= E\left[(X-E(X))^2\right]
+\mathrm{Var}(X) = E\left[(X-E(X))^2\right]
 $$
 
 Variance is the expected squared deviation from the mean.
@@ -401,7 +396,7 @@ $\mathrm{Var}(X)=E[(X-E(X))^2]$
 The standard deviation of $X$ is the square root of its variance:
 
 $$
-\operatorname{SD}(X) = \sqrt{\operatorname{Var}(X)}
+\mathrm{SD}(X) = \sqrt{\mathrm{Var}(X)}
 $$
 
 Common notation:
@@ -431,15 +426,13 @@ and $Y$.
 It is defined by:
 
 $$
-\operatorname{Cov}(X,Y)
-= E\left[(X-E(X))(Y-E(Y))\right]
+\mathrm{Cov}(X,Y) = E\left[(X-E(X))(Y-E(Y))\right]
 $$
 
 It can also be written as:
 
 $$
-\operatorname{Cov}(X,Y)
-= E(XY) - E(X)E(Y)
+\mathrm{Cov}(X,Y) = E(XY) - E(X)E(Y)
 $$
 
 In general:
@@ -476,15 +469,12 @@ $\mathrm{Cov}(X,Y)=E(XY)-E(X)E(Y)$
 The correlation coefficient of $X$ and $Y$ is:
 
 $$
-\rho_{X,Y}
-= \operatorname{Corr}(X,Y)
-= \frac{\operatorname{Cov}(X,Y)}
-{\operatorname{SD}(X)\operatorname{SD}(Y)}
+\rho_{X,Y} = \mathrm{Corr}(X,Y) = \frac{\mathrm{Cov}(X,Y)} {\mathrm{SD}(X)\mathrm{SD}(Y)}
 $$
 
 It rescales covariance to remove the units of $X$ and $Y$.
 
-When $\operatorname{SD}(X)$ and $\operatorname{SD}(Y)$ are both nonzero,
+When $\mathrm{SD}(X)$ and $\mathrm{SD}(Y)$ are both nonzero,
 its range is:
 
 $$
@@ -529,7 +519,7 @@ for all $x$ and $y$.
 
 Important relationship:
 
-- If $X$ and $Y$ are independent, then $\operatorname{Cov}(X,Y)=0$. If $\operatorname{SD}(X)$ and $\operatorname{SD}(Y)$ are both nonzero, then $\rho_{X,Y}=0$.
+- If $X$ and $Y$ are independent, then $\mathrm{Cov}(X,Y)=0$. If $\mathrm{SD}(X)$ and $\mathrm{SD}(Y)$ are both nonzero, then $\rho_{X,Y}=0$.
 - But $\rho_{X,Y}=0$ does not imply independence in general.
 
 <details>
@@ -560,23 +550,21 @@ $\mathrm{Cov}(X,Y)=E(XY)-E(X)E(Y)=0.$
 For constants $a,b$ and random variables $X,Y,Z$:
 
 $$
-\operatorname{Cov}(X,Y) = \operatorname{Cov}(Y,X)
+\mathrm{Cov}(X,Y) = \mathrm{Cov}(Y,X)
 $$
 
 $$
-\operatorname{Cov}(X,X) = \operatorname{Var}(X)
+\mathrm{Cov}(X,X) = \mathrm{Var}(X)
 $$
 
 $$
-\operatorname{Cov}(aX+bY,Z)
-= a\operatorname{Cov}(X,Z) + b\operatorname{Cov}(Y,Z)
+\mathrm{Cov}(aX+bY,Z) = a\mathrm{Cov}(X,Z) + b\mathrm{Cov}(Y,Z)
 $$
 
 For two random variables $X$ and $Y$:
 
 $$
-\operatorname{Var}(X+Y)
-= \operatorname{Var}(X) + 2\operatorname{Cov}(X,Y) + \operatorname{Var}(Y)
+\mathrm{Var}(X+Y) = \mathrm{Var}(X) + 2\mathrm{Cov}(X,Y) + \mathrm{Var}(Y)
 $$
 
 <details>

--- a/NUS/QF1100/summary/Lecture 06.md
+++ b/NUS/QF1100/summary/Lecture 06.md
@@ -90,13 +90,13 @@ $$
 $$
 
 $$
-\alpha^* = \text{weight of asset 1 in the global minimum-variance portfolio}
+\alpha^{\ast} = \text{weight of asset 1 in the global minimum-variance portfolio}
 $$
 
 The corresponding weight of asset 2 in the GMVP is:
 
 $$
-1-\alpha^*
+1-\alpha^{\ast}
 $$
 
 ## Portfolio
@@ -378,25 +378,25 @@ smallest possible variance.
 The minimizing weight is:
 
 $$
-\alpha^* = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
+\alpha^{\ast} = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
 $$
 
 So the GMVP weights are:
 
 $$
-w_1 = \alpha^*, \qquad w_2 = 1-\alpha^*
+w_1 = \alpha^{\ast}, \qquad w_2 = 1-\alpha^{\ast}
 $$
 
 The minimum portfolio variance is:
 
 $$
-(\sigma_p^2)^* = \frac{\sigma_1^2 \sigma_2^2 (1-\rho_{12}^2)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
+(\sigma_p^2)^{\ast} = \frac{\sigma_1^2 \sigma_2^2 (1-\rho_{12}^2)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
 $$
 
 The corresponding portfolio mean is:
 
 $$
-(\mu_p)^* = \alpha^* \mu_1 + (1-\alpha^*)\mu_2
+(\mu_p)^{\ast} = \alpha^{\ast} \mu_1 + (1-\alpha^{\ast})\mu_2
 $$
 
 This portfolio is called the global minimum-variance portfolio because it
@@ -411,7 +411,7 @@ variable $\alpha$, since the other weight is $1-\alpha$.
 That makes $\sigma_p^2$ a quadratic function of $\alpha$, so its graph is
 a parabola. The GMVP is the lowest point of that parabola.
 
-The minimizing value $\alpha^*$ can be found by:
+The minimizing value $\alpha^{\ast}$ can be found by:
 
 - completing the square, or
 - differentiating $\sigma_p^2$ with respect to $\alpha$ and setting the
@@ -419,7 +419,7 @@ The minimizing value $\alpha^*$ can be found by:
 
 The resulting weight
 
-$\alpha^* = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}$
+$\alpha^{\ast} = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}$
 
 gives the smallest possible portfolio variance across all two-asset
 portfolios.
@@ -428,8 +428,8 @@ Intuitively, the GMVP balances the assets so that diversification is used
 as much as possible. The lower the correlation, the more diversification
 can reduce risk.
 
-The formula for $(\sigma_p^2)^*$ is the minimum value of the quadratic
-once $\alpha=\alpha^*$ is substituted back in.
+The formula for $(\sigma_p^2)^{\ast}$ is the minimum value of the quadratic
+once $\alpha=\alpha^{\ast}$ is substituted back in.
 </details>
 
 ## Key Takeaways

--- a/NUS/QF1100/summary/Lecture 06.md
+++ b/NUS/QF1100/summary/Lecture 06.md
@@ -54,31 +54,31 @@ $$
 $$
 
 $$
-\sigma_i^2 = \operatorname{Var}(r_i) = \text{variance of the return of asset } i
+\sigma_i^2 = \mathrm{Var}(r_i) = \text{variance of the return of asset } i
 $$
 
 $$
-\sigma_i = \operatorname{SD}(r_i) = \text{standard deviation of the return of asset } i
+\sigma_i = \mathrm{SD}(r_i) = \text{standard deviation of the return of asset } i
 $$
 
 $$
-\sigma_{ij} = \operatorname{Cov}(r_i,r_j)
+\sigma_{ij} = \mathrm{Cov}(r_i,r_j)
 $$
 
 $$
-\sigma_{12} = \operatorname{Cov}(r_1,r_2)
+\sigma_{12} = \mathrm{Cov}(r_1,r_2)
 $$
 
 $$
-\sigma_p^2 = \operatorname{Var}(r_p) = \text{portfolio variance}
+\sigma_p^2 = \mathrm{Var}(r_p) = \text{portfolio variance}
 $$
 
 $$
-\sigma_p = \operatorname{SD}(r_p) = \text{portfolio standard deviation}
+\sigma_p = \mathrm{SD}(r_p) = \text{portfolio standard deviation}
 $$
 
 $$
-\rho_{ij} = \operatorname{Corr}(r_i,r_j) = \frac{\sigma_{ij}}{\sigma_i \sigma_j} \text{ when } \sigma_i,\sigma_j > 0
+\rho_{ij} = \mathrm{Corr}(r_i,r_j) = \frac{\sigma_{ij}}{\sigma_i \sigma_j} \text{ when } \sigma_i,\sigma_j > 0
 $$
 
 $$
@@ -200,9 +200,7 @@ Let the rate of return of asset $i$ be $r_i$.
 The end-of-period wealth is:
 
 $$
-X_1
-= \sum_{i=1}^n w_i X_0(1+r_i)
-= X_0 \sum_{i=1}^n w_i(1+r_i)
+X_1 = \sum_{i=1}^n w_i X_0(1+r_i) = X_0 \sum_{i=1}^n w_i(1+r_i)
 $$
 
 If $r_p$ is the portfolio return, then:
@@ -305,24 +303,19 @@ This parallels the return formula: expectation preserves weighted sums.
 Let:
 
 $$
-\sigma_{ij} = \operatorname{Cov}(r_i,r_j)
+\sigma_{ij} = \mathrm{Cov}(r_i,r_j)
 $$
 
 Then the portfolio variance is:
 
 $$
-\sigma_p^2
-= \operatorname{Var}(r_p)
-= \sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}
+\sigma_p^2 = \mathrm{Var}(r_p) = \sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}
 $$
 
 For two assets:
 
 $$
-\sigma_p^2
-= \alpha^2 \sigma_1^2
-+ (1-\alpha)^2 \sigma_2^2
-+ 2\alpha(1-\alpha)\sigma_{12}
+\sigma_p^2 = \alpha^2 \sigma_1^2 + (1-\alpha)^2 \sigma_2^2 + 2\alpha(1-\alpha)\sigma_{12}
 $$
 
 Using the correlation coefficient, when $\sigma_1,\sigma_2 > 0$,
@@ -334,10 +327,7 @@ $$
 this becomes:
 
 $$
-\sigma_p^2
-= \alpha^2 \sigma_1^2
-+ (1-\alpha)^2 \sigma_2^2
-+ 2\alpha(1-\alpha)\rho_{12}\sigma_1 \sigma_2
+\sigma_p^2 = \alpha^2 \sigma_1^2 + (1-\alpha)^2 \sigma_2^2 + 2\alpha(1-\alpha)\rho_{12}\sigma_1 \sigma_2
 $$
 
 <details>
@@ -388,10 +378,7 @@ smallest possible variance.
 The minimizing weight is:
 
 $$
-\alpha^*
-=
-\frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)}
-{\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
+\alpha^* = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
 $$
 
 So the GMVP weights are:
@@ -403,10 +390,7 @@ $$
 The minimum portfolio variance is:
 
 $$
-(\sigma_p^2)^*
-=
-\frac{\sigma_1^2 \sigma_2^2 (1-\rho_{12}^2)}
-{\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
+(\sigma_p^2)^* = \frac{\sigma_1^2 \sigma_2^2 (1-\rho_{12}^2)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
 $$
 
 The corresponding portfolio mean is:

--- a/NUS/QF1100/summary/Lecture 06.md
+++ b/NUS/QF1100/summary/Lecture 06.md
@@ -1,0 +1,500 @@
+# Lecture 06
+
+This lecture extends random asset returns to portfolios of risky assets.
+
+The key idea is that once several risky assets are combined, portfolio
+return depends on weighted combinations of individual returns, while portfolio
+risk depends on both individual variances and how the assets move
+together.
+
+## Variable Definitions
+
+$$
+n = \text{number of available assets}
+$$
+
+$$
+i,j = \text{asset indices}
+$$
+
+$$
+X_0 = \text{initial wealth invested at time } 0
+$$
+
+$$
+X_1 = \text{wealth at the end of the investment period}
+$$
+
+$$
+X_{0i} = \text{amount invested in asset } i \text{ at time } 0
+$$
+
+$$
+w_i = \text{portfolio weight of asset } i
+$$
+
+$$
+w = (w_1,w_2,\ldots,w_n) = \text{portfolio weight vector}
+$$
+
+$$
+r_i = \text{rate of return of asset } i
+$$
+
+$$
+r_p = \text{portfolio rate of return}
+$$
+
+$$
+\mu_i = E(r_i) = \text{mean return of asset } i
+$$
+
+$$
+\mu_p = E(r_p) = \text{mean return of the portfolio}
+$$
+
+$$
+\sigma_i^2 = \operatorname{Var}(r_i) = \text{variance of the return of asset } i
+$$
+
+$$
+\sigma_i = \operatorname{SD}(r_i) = \text{standard deviation of the return of asset } i
+$$
+
+$$
+\sigma_{ij} = \operatorname{Cov}(r_i,r_j)
+$$
+
+$$
+\sigma_{12} = \operatorname{Cov}(r_1,r_2)
+$$
+
+$$
+\sigma_p^2 = \operatorname{Var}(r_p) = \text{portfolio variance}
+$$
+
+$$
+\sigma_p = \operatorname{SD}(r_p) = \text{portfolio standard deviation}
+$$
+
+$$
+\rho_{ij} = \operatorname{Corr}(r_i,r_j) = \frac{\sigma_{ij}}{\sigma_i \sigma_j} \text{ when } \sigma_i,\sigma_j > 0
+$$
+
+$$
+\alpha = w_1 = \text{weight of asset 1 in a two-asset portfolio}
+$$
+
+$$
+1-\alpha = w_2 = \text{weight of asset 2 in a two-asset portfolio}
+$$
+
+$$
+\alpha^* = \text{weight of asset 1 in the global minimum-variance portfolio}
+$$
+
+The corresponding weight of asset 2 in the GMVP is:
+
+$$
+1-\alpha^*
+$$
+
+## Portfolio
+
+Suppose there are $n$ assets available and the investor starts with initial
+wealth $X_0$.
+
+A portfolio is formed by choosing amounts
+
+$$
+X_{0i}, \qquad i = 1,2,\ldots,n
+$$
+
+to invest in each asset, such that:
+
+$$
+\sum_{i=1}^n X_{0i} = X_0
+$$
+
+Here $X_{0i}$ is the amount invested in asset $i$.
+
+If short-selling is allowed, some $X_{0i}$ may be negative. Otherwise:
+
+$$
+X_{0i} \ge 0
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A portfolio is just a way of splitting total wealth across several assets.
+
+The condition
+
+$$
+\sum_{i=1}^n X_{0i}=X_0
+$$
+
+says all initial wealth must be allocated somewhere.
+
+If short-selling is allowed, one of the amounts can be negative, meaning
+the investor has effectively borrowed that asset rather than bought it.
+
+So the portfolio is a "master asset" built from the underlying assets.
+</details>
+
+## Portfolio Weights
+
+The invested amounts can be written as fractions of total wealth:
+
+$$
+X_{0i} = w_i X_0
+$$
+
+where $w_i$ is the portfolio weight of asset $i$.
+
+The weights satisfy:
+
+$$
+\sum_{i=1}^n w_i = 1
+$$
+
+If short-selling is allowed, then some weights may be negative:
+
+$$
+w_i < 0
+$$
+
+Otherwise:
+
+$$
+w_i \ge 0
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The weights tell us what fraction of total wealth is placed in each asset.
+
+Since
+
+$$
+X_{0i}=w_iX_0,
+$$
+
+summing over all assets gives:
+
+$$
+\sum_{i=1}^n X_{0i}
+= X_0\sum_{i=1}^n w_i.
+$$
+
+But the left-hand side equals $X_0$, so:
+
+$$
+\sum_{i=1}^n w_i = 1.
+$$
+
+So weights always add up to 100% of the investor's wealth, even if some
+positions are negative because of short-selling.
+
+Negative weights represent short positions, while weights above $1$ can
+occur when short-selling is used to lever a long position elsewhere.
+</details>
+
+## Portfolio Return
+
+Let the rate of return of asset $i$ be $r_i$.
+
+The end-of-period wealth is:
+
+$$
+X_1
+= \sum_{i=1}^n w_i X_0(1+r_i)
+= X_0 \sum_{i=1}^n w_i(1+r_i)
+$$
+
+If $r_p$ is the portfolio return, then:
+
+$$
+X_1 = X_0(1+r_p)
+$$
+
+Comparing the two expressions gives the portfolio return:
+
+$$
+r_p = \sum_{i=1}^n w_i r_i
+$$
+
+So the portfolio return is a weighted combination of the asset returns.
+
+### Two-Asset Portfolio
+
+For two assets, let:
+
+$$
+w_1 = \alpha, \qquad w_2 = 1-\alpha
+$$
+
+Then:
+
+$$
+r_p = \alpha r_1 + (1-\alpha)r_2
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Each asset grows its allocated wealth by its own return factor. Asset $i$
+starts with $w_iX_0$ and ends with:
+
+$$
+w_iX_0(1+r_i)
+$$
+
+Adding over all assets gives total end wealth.
+
+Since portfolio return $r_p$ is defined by:
+
+$$
+X_1=X_0(1+r_p),
+$$
+
+dividing both sides by $X_0$ gives:
+
+$$
+1+r_p=\sum_{i=1}^n w_i(1+r_i)
+$$
+
+and because $\sum_i w_i=1$, this simplifies to:
+
+$$
+r_p=\sum_{i=1}^n w_i r_i.
+$$
+
+So portfolio return is a weighted combination of the asset returns.
+
+In the two-asset case, once $\alpha$ is chosen, the whole portfolio is
+determined because the second weight must be $1-\alpha$.
+</details>
+
+## Portfolio Mean
+
+Let:
+
+$$
+\mu_i = E(r_i)
+$$
+
+be the mean return of asset $i$.
+
+Then the portfolio mean is:
+
+$$
+\mu_p = E(r_p) = \sum_{i=1}^n w_i \mu_i
+$$
+
+For two assets:
+
+$$
+\mu_p = \alpha \mu_1 + (1-\alpha)\mu_2
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Since
+
+$$
+r_p=\sum_{i=1}^n w_i r_i,
+$$
+
+taking expectation and using linearity gives:
+
+$$
+E(r_p)
+= E\left(\sum_{i=1}^n w_i r_i\right)
+= \sum_{i=1}^n w_i E(r_i)
+= \sum_{i=1}^n w_i \mu_i.
+$$
+
+So the portfolio mean is simply the weighted combination of individual asset
+means.
+
+This parallels the return formula: expectation preserves weighted sums.
+</details>
+
+## Portfolio Variance
+
+Let:
+
+$$
+\sigma_{ij} = \operatorname{Cov}(r_i,r_j)
+$$
+
+Then the portfolio variance is:
+
+$$
+\sigma_p^2
+= \operatorname{Var}(r_p)
+= \sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}
+$$
+
+For two assets:
+
+$$
+\sigma_p^2
+= \alpha^2 \sigma_1^2
++ (1-\alpha)^2 \sigma_2^2
++ 2\alpha(1-\alpha)\sigma_{12}
+$$
+
+Using the correlation coefficient, when $\sigma_1,\sigma_2 > 0$,
+
+$$
+\rho_{12} = \frac{\sigma_{12}}{\sigma_1 \sigma_2}
+$$
+
+this becomes:
+
+$$
+\sigma_p^2
+= \alpha^2 \sigma_1^2
++ (1-\alpha)^2 \sigma_2^2
++ 2\alpha(1-\alpha)\rho_{12}\sigma_1 \sigma_2
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Portfolio risk is not just a weighted average of individual risks,
+because the assets may move together.
+
+Starting from the two-asset formula
+
+$$
+r_p=\alpha r_1+(1-\alpha)r_2,
+$$
+
+the variance-of-a-sum formula gives:
+
+$$
+\operatorname{Var}(X+Y)
+= \operatorname{Var}(X)+\operatorname{Var}(Y)+2\operatorname{Cov}(X,Y).
+$$
+
+Applying this with
+$X=\alpha r_1$ and $Y=(1-\alpha)r_2$ gives:
+
+$$
+\sigma_p^2
+= \alpha^2\sigma_1^2
++ (1-\alpha)^2\sigma_2^2
++ 2\alpha(1-\alpha)\sigma_{12}.
+$$
+
+The covariance term is what captures diversification.
+
+- If the assets tend to move together strongly, covariance is large and
+  diversification helps less.
+- If they move differently, covariance is smaller and diversification
+  reduces risk more.
+
+Rewriting with correlation is often useful because $\rho_{12}$ is unit-free
+when it is defined.
+
+In the general $n$-asset case, the double sum
+
+$$
+\sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}
+$$
+
+collects all own-variance terms ($i=j$) and all cross-covariance terms
+($i \ne j$).
+</details>
+
+## Global Minimum-Variance Portfolio
+
+For two risky assets, the portfolio variance is a quadratic function of
+$\alpha$.
+
+The global minimum-variance portfolio, or GMVP, is the portfolio with the
+smallest possible variance.
+
+The minimizing weight is:
+
+$$
+\alpha^*
+=
+\frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)}
+{\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
+$$
+
+So the GMVP weights are:
+
+$$
+w_1 = \alpha^*, \qquad w_2 = 1-\alpha^*
+$$
+
+The minimum portfolio variance is:
+
+$$
+(\sigma_p^2)^*
+=
+\frac{\sigma_1^2 \sigma_2^2 (1-\rho_{12}^2)}
+{\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
+$$
+
+The corresponding portfolio mean is:
+
+$$
+(\mu_p)^* = \alpha^* \mu_1 + (1-\alpha^*)\mu_2
+$$
+
+This portfolio is called the global minimum-variance portfolio because it
+has the lowest variance among all portfolios formed from the two assets.
+
+<details>
+<summary>Intuition / proof</summary>
+
+For two assets, portfolio variance depends only on the single choice
+variable $\alpha$, since the other weight is $1-\alpha$.
+
+That makes $\sigma_p^2$ a quadratic function of $\alpha$, so its graph is
+a parabola. The GMVP is the lowest point of that parabola.
+
+The minimizing value $\alpha^*$ can be found by:
+
+- completing the square, or
+- differentiating $\sigma_p^2$ with respect to $\alpha$ and setting the
+  derivative equal to zero.
+
+The resulting weight
+
+$$
+\alpha^*
+=
+\frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)}
+{\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
+$$
+
+gives the smallest possible portfolio variance across all two-asset
+portfolios.
+
+Intuitively, the GMVP balances the assets so that diversification is used
+as much as possible. The lower the correlation, the more diversification
+can reduce risk.
+
+The formula for $(\sigma_p^2)^*$ is the minimum value of the quadratic
+once $\alpha=\alpha^*$ is substituted back in.
+</details>
+
+## Key Takeaways
+
+- A portfolio allocates total wealth across several assets.
+- Portfolio weights satisfy $\sum_{i=1}^n w_i = 1$.
+- Portfolio return is the weighted sum of asset returns.
+- Portfolio mean is the weighted sum of asset means.
+- Portfolio variance depends on both individual asset risk and covariance between assets.
+- Correlation helps describe how much diversification reduces risk.
+- The GMVP is the portfolio with the lowest possible variance.

--- a/NUS/QF1100/summary/Lecture 06.md
+++ b/NUS/QF1100/summary/Lecture 06.md
@@ -131,7 +131,7 @@ A portfolio is just a way of splitting total wealth across several assets.
 
 The condition
 
-$\displaystyle \sum_{i=1}^n X_{0i}=X_0$
+$\sum_{i=1}^n X_{0i}=X_0$
 
 says all initial wealth must be allocated somewhere.
 
@@ -176,15 +176,15 @@ The weights tell us what fraction of total wealth is placed in each asset.
 
 Since
 
-$\displaystyle X_{0i}=w_iX_0,$
+$X_{0i}=w_iX_0,$
 
 summing over all assets gives:
 
-$\displaystyle \sum_{i=1}^n X_{0i} = X_0\sum_{i=1}^n w_i.$
+$\sum_{i=1}^n X_{0i} = X_0\sum_{i=1}^n w_i.$
 
 But the left-hand side equals $X_0$, so:
 
-$\displaystyle \sum_{i=1}^n w_i = 1.$
+$\sum_{i=1}^n w_i = 1.$
 
 So weights always add up to 100% of the investor's wealth, even if some
 positions are negative because of short-selling.
@@ -239,21 +239,21 @@ $$
 Each asset grows its allocated wealth by its own return factor. Asset $i$
 starts with $w_iX_0$ and ends with:
 
-$\displaystyle w_iX_0(1+r_i)$
+$w_iX_0(1+r_i)$
 
 Adding over all assets gives total end wealth.
 
 Since portfolio return $r_p$ is defined by:
 
-$\displaystyle X_1=X_0(1+r_p),$
+$X_1=X_0(1+r_p),$
 
 dividing both sides by $X_0$ gives:
 
-$\displaystyle 1+r_p=\sum_{i=1}^n w_i(1+r_i)$
+$1+r_p=\sum_{i=1}^n w_i(1+r_i)$
 
 and because $\sum_i w_i=1$, this simplifies to:
 
-$\displaystyle r_p=\sum_{i=1}^n w_i r_i.$
+$r_p=\sum_{i=1}^n w_i r_i.$
 
 So portfolio return is a weighted combination of the asset returns.
 
@@ -288,11 +288,11 @@ $$
 
 Since
 
-$\displaystyle r_p=\sum_{i=1}^n w_i r_i,$
+$r_p=\sum_{i=1}^n w_i r_i,$
 
 taking expectation and using linearity gives:
 
-$\displaystyle E(r_p) = E\left(\sum_{i=1}^n w_i r_i\right) = \sum_{i=1}^n w_i E(r_i) = \sum_{i=1}^n w_i \mu_i.$
+$E(r_p) = E(\sum_{i=1}^n w_i r_i) = \sum_{i=1}^n w_i E(r_i) = \sum_{i=1}^n w_i \mu_i.$
 
 So the portfolio mean is simply the weighted combination of individual asset
 means.
@@ -348,16 +348,16 @@ because the assets may move together.
 
 Starting from the two-asset formula
 
-$\displaystyle r_p=\alpha r_1+(1-\alpha)r_2,$
+$r_p=\alpha r_1+(1-\alpha)r_2,$
 
 the variance-of-a-sum formula gives:
 
-$\displaystyle \operatorname{Var}(X+Y) = \operatorname{Var}(X)+\operatorname{Var}(Y)+2\operatorname{Cov}(X,Y).$
+$\mathrm{Var}(X+Y) = \mathrm{Var}(X)+\mathrm{Var}(Y)+2\mathrm{Cov}(X,Y).$
 
 Applying this with
 $X=\alpha r_1$ and $Y=(1-\alpha)r_2$ gives:
 
-$\displaystyle \sigma_p^2 = \alpha^2\sigma_1^2 + (1-\alpha)^2\sigma_2^2 + 2\alpha(1-\alpha)\sigma_{12}.$
+$\sigma_p^2 = \alpha^2\sigma_1^2 + (1-\alpha)^2\sigma_2^2 + 2\alpha(1-\alpha)\sigma_{12}.$
 
 The covariance term is what captures diversification.
 
@@ -371,7 +371,7 @@ when it is defined.
 
 In the general $n$-asset case, the double sum
 
-$\displaystyle \sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}$
+$\sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}$
 
 collects all own-variance terms ($i=j$) and all cross-covariance terms
 ($i \ne j$).
@@ -435,7 +435,7 @@ The minimizing value $\alpha^*$ can be found by:
 
 The resulting weight
 
-$\displaystyle \alpha^* = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}$
+$\alpha^* = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}$
 
 gives the smallest possible portfolio variance across all two-asset
 portfolios.

--- a/NUS/QF1100/summary/Lecture 06.md
+++ b/NUS/QF1100/summary/Lecture 06.md
@@ -131,9 +131,7 @@ A portfolio is just a way of splitting total wealth across several assets.
 
 The condition
 
-$$
-\sum_{i=1}^n X_{0i}=X_0
-$$
+$\displaystyle \sum_{i=1}^n X_{0i}=X_0$
 
 says all initial wealth must be allocated somewhere.
 
@@ -178,22 +176,15 @@ The weights tell us what fraction of total wealth is placed in each asset.
 
 Since
 
-$$
-X_{0i}=w_iX_0,
-$$
+$\displaystyle X_{0i}=w_iX_0,$
 
 summing over all assets gives:
 
-$$
-\sum_{i=1}^n X_{0i}
-= X_0\sum_{i=1}^n w_i.
-$$
+$\displaystyle \sum_{i=1}^n X_{0i} = X_0\sum_{i=1}^n w_i.$
 
 But the left-hand side equals $X_0$, so:
 
-$$
-\sum_{i=1}^n w_i = 1.
-$$
+$\displaystyle \sum_{i=1}^n w_i = 1.$
 
 So weights always add up to 100% of the investor's wealth, even if some
 positions are negative because of short-selling.
@@ -248,29 +239,21 @@ $$
 Each asset grows its allocated wealth by its own return factor. Asset $i$
 starts with $w_iX_0$ and ends with:
 
-$$
-w_iX_0(1+r_i)
-$$
+$\displaystyle w_iX_0(1+r_i)$
 
 Adding over all assets gives total end wealth.
 
 Since portfolio return $r_p$ is defined by:
 
-$$
-X_1=X_0(1+r_p),
-$$
+$\displaystyle X_1=X_0(1+r_p),$
 
 dividing both sides by $X_0$ gives:
 
-$$
-1+r_p=\sum_{i=1}^n w_i(1+r_i)
-$$
+$\displaystyle 1+r_p=\sum_{i=1}^n w_i(1+r_i)$
 
 and because $\sum_i w_i=1$, this simplifies to:
 
-$$
-r_p=\sum_{i=1}^n w_i r_i.
-$$
+$\displaystyle r_p=\sum_{i=1}^n w_i r_i.$
 
 So portfolio return is a weighted combination of the asset returns.
 
@@ -305,18 +288,11 @@ $$
 
 Since
 
-$$
-r_p=\sum_{i=1}^n w_i r_i,
-$$
+$\displaystyle r_p=\sum_{i=1}^n w_i r_i,$
 
 taking expectation and using linearity gives:
 
-$$
-E(r_p)
-= E\left(\sum_{i=1}^n w_i r_i\right)
-= \sum_{i=1}^n w_i E(r_i)
-= \sum_{i=1}^n w_i \mu_i.
-$$
+$\displaystyle E(r_p) = E\left(\sum_{i=1}^n w_i r_i\right) = \sum_{i=1}^n w_i E(r_i) = \sum_{i=1}^n w_i \mu_i.$
 
 So the portfolio mean is simply the weighted combination of individual asset
 means.
@@ -372,26 +348,16 @@ because the assets may move together.
 
 Starting from the two-asset formula
 
-$$
-r_p=\alpha r_1+(1-\alpha)r_2,
-$$
+$\displaystyle r_p=\alpha r_1+(1-\alpha)r_2,$
 
 the variance-of-a-sum formula gives:
 
-$$
-\operatorname{Var}(X+Y)
-= \operatorname{Var}(X)+\operatorname{Var}(Y)+2\operatorname{Cov}(X,Y).
-$$
+$\displaystyle \operatorname{Var}(X+Y) = \operatorname{Var}(X)+\operatorname{Var}(Y)+2\operatorname{Cov}(X,Y).$
 
 Applying this with
 $X=\alpha r_1$ and $Y=(1-\alpha)r_2$ gives:
 
-$$
-\sigma_p^2
-= \alpha^2\sigma_1^2
-+ (1-\alpha)^2\sigma_2^2
-+ 2\alpha(1-\alpha)\sigma_{12}.
-$$
+$\displaystyle \sigma_p^2 = \alpha^2\sigma_1^2 + (1-\alpha)^2\sigma_2^2 + 2\alpha(1-\alpha)\sigma_{12}.$
 
 The covariance term is what captures diversification.
 
@@ -405,9 +371,7 @@ when it is defined.
 
 In the general $n$-asset case, the double sum
 
-$$
-\sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}
-$$
+$\displaystyle \sum_{i=1}^n \sum_{j=1}^n w_i w_j \sigma_{ij}$
 
 collects all own-variance terms ($i=j$) and all cross-covariance terms
 ($i \ne j$).
@@ -471,12 +435,7 @@ The minimizing value $\alpha^*$ can be found by:
 
 The resulting weight
 
-$$
-\alpha^*
-=
-\frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)}
-{\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}
-$$
+$\displaystyle \alpha^* = \frac{\sigma_2(\sigma_2-\rho_{12}\sigma_1)} {\sigma_1^2+\sigma_2^2-2\rho_{12}\sigma_1 \sigma_2}$
 
 gives the smallest possible portfolio variance across all two-asset
 portfolios.

--- a/NUS/QF1100/summary/Lecture 07.md
+++ b/NUS/QF1100/summary/Lecture 07.md
@@ -89,8 +89,7 @@ IM,MM = \text{initial margin requirement and maintenance margin requirement}
 $$
 
 $$
-A_T^{\text{long}},A_T^{\text{short}}
-= \text{accrued profit at maturity for long and short futures positions}
+A_T^{\text{long}},A_T^{\text{short}} = \text{accrued profit at maturity for long and short futures positions}
 $$
 
 $$
@@ -470,35 +469,26 @@ For a long futures position held from time $0$ to maturity $T$, the accrued
 profit at time $T$ is:
 
 $$
-A_T^{\text{long}}
-= \sum_{i=1}^{N}
-\left[F(i)-F(i-1)\right]R^{N-i}
+A_T^{\text{long}} = \sum_{i=1}^{N} \left[F(i)-F(i-1)\right]R^{N-i}
 $$
 
 For a position with contract size $Q$, multiply by $Q$:
 
 $$
-QA_T^{\text{long}}
-= Q\sum_{i=1}^{N}
-\left[F(i)-F(i-1)\right]R^{N-i}
+QA_T^{\text{long}} = Q\sum_{i=1}^{N} \left[F(i)-F(i-1)\right]R^{N-i}
 $$
 
 For a short futures position, the accrued profit is:
 
 $$
-A_T^{\text{short}}
-= -\sum_{i=1}^{N}
-\left[F(i)-F(i-1)\right]R^{N-i}
+A_T^{\text{short}} = -\sum_{i=1}^{N} \left[F(i)-F(i-1)\right]R^{N-i}
 $$
 
 If the interest rate is zero, then $R=1$ and the long futures profit
 telescopes:
 
 $$
-A_T^{\text{long}}
-= \sum_{i=1}^{N}
-\left[F(i)-F(i-1)\right]
-= F(N)-F(0)
+A_T^{\text{long}} = \sum_{i=1}^{N} \left[F(i)-F(i-1)\right] = F(N)-F(0)
 $$
 
 Since $F(N)=S(T)$ at maturity:
@@ -558,10 +548,7 @@ with the same maturity should have the same delivery price if:
 For this course, the simplifying assumption is:
 
 $$
-F_{\text{forward}}(t,T)
-= F_{\text{future}}(t,T)
-= F(t,T)
-= S_t e^{r(T-t)}
+F_{\text{forward}}(t,T) = F_{\text{future}}(t,T) = F(t,T) = S_t e^{r(T-t)}
 $$
 
 <details>

--- a/NUS/QF1100/summary/Lecture 07.md
+++ b/NUS/QF1100/summary/Lecture 07.md
@@ -1,0 +1,624 @@
+# Lecture 07
+
+This lecture introduces forward and futures contracts as derivatives whose
+values depend on an underlying asset.
+
+The key idea is that both contracts fix a price for future delivery, but
+forwards settle only at maturity while futures are marked to market daily.
+
+## Variable Definitions
+
+$$
+t = \text{current time or contract initiation time}
+$$
+
+$$
+T = \text{expiration, maturity, or delivery date}
+$$
+
+$$
+0 = \text{initial time}
+$$
+
+$$
+N = \text{number of daily settlement intervals from time } 0 \text{ to maturity } T
+$$
+
+$$
+i = \text{daily settlement index, where } i=0,1,\ldots,N
+$$
+
+$$
+S_0 = \text{spot price of the underlying asset today}
+$$
+
+$$
+S_t = \text{spot price of the underlying asset at time } t
+$$
+
+$$
+S_T = \text{spot price of the underlying asset at maturity}
+$$
+
+$$
+S(T) = S_T = \text{spot price at maturity}
+$$
+
+$$
+F(t,T) = \text{forward or futures delivery price agreed at time } t \text{ for delivery at } T
+$$
+
+$$
+F(0,T) = \text{delivery price agreed today for maturity } T
+$$
+
+$$
+F(i) = \text{futures price on day } i
+$$
+
+$$
+F(N)=F(T)=\text{futures price on the final settlement day, which is maturity}
+$$
+
+$$
+F(0) = \text{initial futures price}
+$$
+
+$$
+r = \text{risk-free interest rate per annum}
+$$
+
+$$
+R = e^{r/365} = \text{daily accumulation factor under continuous compounding}
+$$
+
+$$
+Q = \text{contract size}
+$$
+
+$$
+V_{\text{ct}} = \text{total contract value of a futures position}
+$$
+
+$$
+m_I,m_M = \text{initial margin rate and maintenance margin rate}
+$$
+
+$$
+IM,MM = \text{initial margin requirement and maintenance margin requirement}
+$$
+
+$$
+A_T^{\text{long}},A_T^{\text{short}}
+= \text{accrued profit at maturity for long and short futures positions}
+$$
+
+$$
+U,V = \text{two portfolios or trading strategies}
+$$
+
+$$
+U_0,V_0 = \text{time-0 prices of portfolios } U \text{ and } V
+$$
+
+$$
+U_T,V_T = \text{time-}T \text{ payoffs of portfolios } U \text{ and } V
+$$
+
+$$
+F_{\text{forward}}(t,T) = \text{forward delivery price}
+$$
+
+$$
+F_{\text{future}}(t,T) = \text{futures delivery price}
+$$
+
+Unless otherwise stated, the lecture assumes no money changes hands when
+entering a forward contract, so its initial cost is zero.
+
+## Forward Market
+
+A forward contract is an obligation to buy or sell an underlying asset at
+a specific price and at a specific time in the future.
+
+The buyer of the forward contract is said to be long. The seller is said
+to be short.
+
+The spot market is the market for immediate delivery. The spot price is
+the price for immediate delivery:
+
+$$
+S_t
+$$
+
+The forward price is the price that applies at future delivery:
+
+$$
+F(t,T)
+$$
+
+Unless otherwise stated, the lecture assumes no money changes hands
+before maturity. Under this assumption, the forward payoff and profit are
+the same.
+
+Long forward payoff:
+
+$$
+S_T - F(t,T)
+$$
+
+Short forward payoff:
+
+$$
+F(t,T) - S_T
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A forward contract fixes the transaction price now, but the actual exchange
+happens later at time $T$.
+
+Under the lecture's assumption, the contract costs nothing to enter at
+time $t$. So:
+
+$$
+\text{profit} = \text{payoff} - \text{initial cost} = \text{payoff}.
+$$
+
+If you are long, you agree to buy at price $F(t,T)$. At maturity, the
+asset is worth $S_T$ in the market, so your net gain is:
+
+$$
+S_T-F(t,T)
+$$
+
+If you are short, you agree to sell at price $F(t,T)$, so your gain is:
+
+$$
+F(t,T)-S_T
+$$
+
+This also explains the sign:
+
+- if $S_T>F(t,T)$, the long benefits because it buys below market value
+- if $S_T<F(t,T)$, the short benefits because it sells above market value
+
+These are exact opposites, which makes sense because every long position
+is paired with a short position in the same contract.
+</details>
+
+## No-Arbitrage Principle and Law of One Price
+
+An arbitrage opportunity is a strategy that makes a riskless profit.
+
+The no-arbitrage principle says there cannot be two portfolio strategies
+with the same initial cost such that one always gives a better final payoff
+than the other.
+
+The law of one price follows from no-arbitrage:
+
+If two portfolios $U$ and $V$ have the same payoff at time $T$,
+
+$$
+U_T = V_T
+$$
+
+then they must have the same price at time $0$:
+
+$$
+U_0 = V_0
+$$
+
+Otherwise, investors could buy the cheaper portfolio and sell the more
+expensive portfolio to earn arbitrage profit.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The no-arbitrage principle is the backbone of derivative pricing.
+
+If two strategies end with exactly the same payoff, then paying more for
+one than the other would be irrational in a competitive market.
+
+Suppose $U_T=V_T$ but $U_0<V_0$. Then an investor could:
+
+- buy $U$
+- sell $V$
+
+The initial cash flow would be positive, since $V$ is sold for more than
+$U$ costs, while the final payoff would cancel out because the two
+portfolios have the same payoff.
+
+That creates arbitrage, so equal payoffs must imply equal prices.
+
+In practice, derivative pricing often works by:
+
+1. building a portfolio that replicates the derivative payoff
+2. using the law of one price to say the derivative and the replicating
+   portfolio must have the same value
+</details>
+
+## Forward Price by No-Arbitrage
+
+Consider a non-dividend-paying asset with current spot price $S_0$.
+Assume the risk-free interest rate is $r$ per annum, compounded
+continuously.
+
+By no-arbitrage, the forward price is:
+
+$$
+F(0,T) = S_0 e^{rT}
+$$
+
+For a general time $t$:
+
+$$
+F(t,T) = S_t e^{r(T-t)}
+$$
+
+Important point:
+
+$$
+F(t,T)
+$$
+
+depends on the spot price, risk-free rate, and time to maturity. It does
+not depend on the expected rate of return of the underlying asset.
+
+<details>
+<summary>Intuition / proof</summary>
+
+To lock in delivery of the asset at time $T$, there are two equivalent
+strategies:
+
+1. buy the asset now for $S_0$ and carry it to time $T$
+2. enter a forward contract today for delivery at time $T$
+
+If you buy the asset now using borrowed money at risk-free rate $r$, then
+the time-$T$ cost of that strategy is:
+
+$$
+S_0 e^{rT}
+$$
+
+No arbitrage says the forward delivery price must match that carrying
+cost, so:
+
+$$
+F(0,T)=S_0e^{rT}
+$$
+
+The same logic at a later time $t$ gives:
+
+$$
+F(t,T)=S_t e^{r(T-t)}.
+$$
+
+Another way to see this is by arbitrage bounds:
+
+- if $F(0,T)>S_0e^{rT}$, then sell the forward, buy the asset now, and
+  finance the purchase by borrowing
+- if $F(0,T)<S_0e^{rT}$, then buy the forward, short-sell the asset now,
+  and invest the short-sale proceeds at the risk-free rate
+
+In either case, a mismatch between forward price and carrying cost creates
+a riskless profit opportunity.
+
+This formula comes from replication and no-arbitrage, not from guessing
+where the asset price is expected to go.
+</details>
+
+## Futures
+
+A futures contract is a standardized legal contract to buy or sell an
+underlying asset at a predetermined price for delivery at a specified
+future time.
+
+Unlike forwards, futures are traded on organized exchanges. The exchange
+standardizes the contract and reduces counterparty risk through a
+clearinghouse, margins, and daily settlement.
+
+<details>
+<summary>Intuition / proof</summary>
+
+A forward contract is private and customized. A futures contract is
+standardized and exchange-traded.
+
+Standardization makes it easier to trade in and out of the position, while
+the clearinghouse reduces the risk that the other party defaults.
+
+A useful mental picture is:
+
+- in a forward, your direct counterparty matters
+- in a futures contract, the exchange clearinghouse effectively stands
+  between buyers and sellers
+</details>
+
+## Forwards vs Futures
+
+| Feature | Forward Contract | Futures Contract |
+|---|---|---|
+| Trading venue | Over-the-counter private agreement | Exchange-traded |
+| Contract terms | Customized | Standardized |
+| Liquidity | Lower, harder to exit early | Higher, easier to buy or sell |
+| Counterparty risk | Higher, depends on the other party | Lower, clearinghouse guarantees trade |
+| Settlement | Physical or cash settlement at maturity | Can be settled daily or before maturity |
+| Margin and collateral | Typically no margin, depends on contract | Requires initial and maintenance margin |
+| Marking to market | No daily settlement | Marked to market daily |
+
+<details>
+<summary>Intuition / proof</summary>
+
+The economic role of forwards and futures is similar: both set a price for
+future delivery.
+
+The operational differences matter in practice:
+
+- forwards are flexible but less liquid and riskier counterparty-wise
+- futures are standardized, easier to trade, and safer because of exchange
+  clearing and margining
+
+So the main difference is usually not the payoff idea, but the trading
+mechanism and the timing of cash flows.
+</details>
+
+## Margin
+
+Futures traders must open a margin account with a broker.
+
+### Initial Margin
+
+The initial margin is the amount that must be deposited when the futures
+position is opened.
+
+It is usually a fraction of the total contract value:
+
+$$
+IM = m_I V_{\text{ct}}
+$$
+
+### Maintenance Margin
+
+The maintenance margin is the minimum account value that must be
+maintained.
+
+$$
+MM = m_M V_{\text{ct}}
+$$
+
+If the margin account falls below the maintenance margin, a margin call is
+issued. The trader must add funds, otherwise the futures position may be
+closed out.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Margin is a performance bond, not the full purchase price of the asset.
+
+- the initial margin opens the position
+- the maintenance margin is the minimum balance needed to keep it open
+
+Because futures are marked to market daily, the margin account absorbs
+daily gains and losses. A margin call happens when losses push the account
+below the required maintenance level.
+
+So margin exists because exchange-traded futures do not wait until maturity
+to discover gains and losses. The market wants enough cash in the account
+to cover day-to-day adverse price moves.
+</details>
+
+## Daily Settlement
+
+Daily settlement, or marking to market, means futures gains and losses
+are settled every day.
+
+Let $F(i)$ be the futures price on day $i$, where $i=0,1,\ldots,N$ and
+day $N$ is the maturity date $T$.
+
+For a long futures position, the daily cash flow from day $i-1$ to day $i$
+is:
+
+$$
+F(i) - F(i-1)
+$$
+
+For a short futures position, the daily cash flow is:
+
+$$
+F(i-1) - F(i)
+$$
+
+At maturity, the futures price converges to the spot price:
+
+$$
+F(N) = F(T) = S(T)
+$$
+
+Otherwise, an arbitrage opportunity would exist.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Marking to market updates the contract each day as if gains and losses are
+immediately realized.
+
+This is the lecture's idea of "revising the contract as the price
+environment changes." Instead of keeping one old delivery price all the way
+to maturity, the contract is effectively reset each day by paying out that
+day's gain or loss in cash.
+
+For a long position:
+
+- if the futures price rises, the position gains value, so the holder
+  receives cash
+- if the futures price falls, the holder pays cash
+
+That is why the daily cash flow is:
+
+$$
+F(i)-F(i-1)
+$$
+
+At maturity, the futures contract becomes a contract for immediate
+delivery, so the futures price must equal the spot price:
+
+$$
+F(N)=F(T)=S(T)
+$$
+
+If they differed, an investor could lock in an arbitrage by combining a
+futures position with immediate spot-market trading.
+</details>
+
+## Accrued Profit
+
+Accrued profit is the total accumulated profit from all daily settlement
+cash flows, including interest earned or paid on those cash flows.
+
+Let the daily accumulation factor be:
+
+$$
+R = e^{r/365}
+$$
+
+For a long futures position held from time $0$ to maturity $T$, the accrued
+profit at time $T$ is:
+
+$$
+A_T^{\text{long}}
+= \sum_{i=1}^{N}
+\left[F(i)-F(i-1)\right]R^{N-i}
+$$
+
+For a position with contract size $Q$, multiply by $Q$:
+
+$$
+QA_T^{\text{long}}
+= Q\sum_{i=1}^{N}
+\left[F(i)-F(i-1)\right]R^{N-i}
+$$
+
+For a short futures position, the accrued profit is:
+
+$$
+A_T^{\text{short}}
+= -\sum_{i=1}^{N}
+\left[F(i)-F(i-1)\right]R^{N-i}
+$$
+
+If the interest rate is zero, then $R=1$ and the long futures profit
+telescopes:
+
+$$
+A_T^{\text{long}}
+= \sum_{i=1}^{N}
+\left[F(i)-F(i-1)\right]
+= F(N)-F(0)
+$$
+
+Since $F(N)=S(T)$ at maturity:
+
+$$
+A_T^{\text{long}} = S(T)-F(0)
+$$
+
+This is the same as the profit from a long forward contract with delivery
+date $T$ and delivery price equal to the initial futures price $F(0)$ when
+interest is zero.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The key difference between futures and forwards is timing of cash flows.
+
+A futures gain received early can earn interest for longer, while a loss
+paid early has financing consequences too.
+
+That is why accrued profit is not just the sum of daily cash flows, but
+the accumulated value of those cash flows at time $T$:
+
+$$
+A_T^{\text{long}}=\sum_{i=1}^{N}[F(i)-F(i-1)]R^{N-i}
+$$
+
+The factor $R^{N-i}$ means the cash flow received on day $i$ is carried
+forward for the remaining $N-i$ days until maturity.
+
+If $r=0$, then $R=1$, so the expression simplifies to a telescoping sum:
+
+$$
+[F(N)-F(N-1)] + \cdots + [F(1)-F(0)] = F(N)-F(0).
+$$
+
+Since $F(N)=S(T)$, the total futures profit becomes:
+
+$$
+A_T^{\text{long}}=S(T)-F(0),
+$$
+
+which is exactly the long forward profit. This is the first hint of
+forward-futures equivalence.
+</details>
+
+## Forward-Futures Equivalence
+
+Forwards and futures both set a price for future delivery. The main
+difference is their cash flow timing:
+
+- Forwards have no cash flow until maturity.
+- Futures have daily cash flows due to marking to market.
+
+In theory, forward and futures contracts on the same underlying asset and
+with the same maturity should have the same delivery price if:
+
+- there is no arbitrage;
+- there are no transaction costs;
+- interest rates are deterministic;
+- interest rates are not correlated with the underlying asset price.
+
+For this course, the simplifying assumption is:
+
+$$
+F_{\text{forward}}(t,T)
+= F_{\text{future}}(t,T)
+= F(t,T)
+= S_t e^{r(T-t)}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+In general, forwards and futures need not be exactly identical because
+futures generate interim cash flows while forwards do not.
+
+Those interim cash flows matter when:
+
+- interest rates are random, or
+- interest rates are related to the underlying asset price
+
+For example, if gains tend to arrive exactly when interest rates are high,
+daily settlement becomes more valuable because those gains can be reinvested
+at better rates.
+
+But under the lecture's simplifying assumptions, the reinvestment effect
+does not distort prices, so the two delivery prices coincide:
+
+$$
+F_{\text{forward}}(t,T)=F_{\text{future}}(t,T)=F(t,T).
+$$
+
+So for this course, forwards and futures can be priced using the same
+no-arbitrage formula.
+</details>
+
+## Key Takeaways
+
+- A forward is a private agreement for future delivery.
+- A future is standardized, exchange-traded, and marked to market daily.
+- No-arbitrage gives $F(t,T)=S_t e^{r(T-t)}$ for a non-dividend-paying asset under continuous compounding.
+- Long forwards and futures benefit when the underlying or futures price rises.
+- Short forwards and futures benefit when the underlying or futures price falls.
+- Futures require initial margin and maintenance margin.
+- Accrued profit tracks the accumulated value of daily settlement cash flows.
+- Under the course assumptions, forward and futures delivery prices are treated as equal.

--- a/NUS/QF1100/summary/Lecture 07.md
+++ b/NUS/QF1100/summary/Lecture 07.md
@@ -162,16 +162,16 @@ happens later at time $T$.
 Under the lecture's assumption, the contract costs nothing to enter at
 time $t$. So:
 
-$\displaystyle \text{profit} = \text{payoff} - \text{initial cost} = \text{payoff}.$
+profit = payoff - initial cost = payoff.
 
 If you are long, you agree to buy at price $F(t,T)$. At maturity, the
 asset is worth $S_T$ in the market, so your net gain is:
 
-$\displaystyle S_T-F(t,T)$
+$S_T-F(t,T)$
 
 If you are short, you agree to sell at price $F(t,T)$, so your gain is:
 
-$\displaystyle F(t,T)-S_T$
+$F(t,T)-S_T$
 
 This also explains the sign:
 
@@ -272,16 +272,16 @@ strategies:
 If you buy the asset now using borrowed money at risk-free rate $r$, then
 the time-$T$ cost of that strategy is:
 
-$\displaystyle S_0 e^{rT}$
+$S_0 e^{rT}$
 
 No arbitrage says the forward delivery price must match that carrying
 cost, so:
 
-$\displaystyle F(0,T)=S_0e^{rT}$
+$F(0,T)=S_0e^{rT}$
 
 The same logic at a later time $t$ gives:
 
-$\displaystyle F(t,T)=S_t e^{r(T-t)}.$
+$F(t,T)=S_t e^{r(T-t)}.$
 
 Another way to see this is by arbitrage bounds:
 
@@ -444,12 +444,12 @@ For a long position:
 
 That is why the daily cash flow is:
 
-$\displaystyle F(i)-F(i-1)$
+$F(i)-F(i-1)$
 
 At maturity, the futures contract becomes a contract for immediate
 delivery, so the futures price must equal the spot price:
 
-$\displaystyle F(N)=F(T)=S(T)$
+$F(N)=F(T)=S(T)$
 
 If they differed, an investor could lock in an arbitrage by combining a
 futures position with immediate spot-market trading.
@@ -522,18 +522,18 @@ paid early has financing consequences too.
 That is why accrued profit is not just the sum of daily cash flows, but
 the accumulated value of those cash flows at time $T$:
 
-$\displaystyle A_T^{\text{long}}=\sum_{i=1}^{N}[F(i)-F(i-1)]R^{N-i}$
+$A_T^{\mathrm{long}}=\sum_{i=1}^{N}[F(i)-F(i-1)]R^{N-i}$
 
 The factor $R^{N-i}$ means the cash flow received on day $i$ is carried
 forward for the remaining $N-i$ days until maturity.
 
 If $r=0$, then $R=1$, so the expression simplifies to a telescoping sum:
 
-$\displaystyle [F(N)-F(N-1)] + \cdots + [F(1)-F(0)] = F(N)-F(0).$
+$[F(N)-F(N-1)] + \cdots + [F(1)-F(0)] = F(N)-F(0).$
 
 Since $F(N)=S(T)$, the total futures profit becomes:
 
-$\displaystyle A_T^{\text{long}}=S(T)-F(0),$
+$A_T^{\mathrm{long}}=S(T)-F(0),$
 
 which is exactly the long forward profit. This is the first hint of
 forward-futures equivalence.
@@ -582,7 +582,7 @@ at better rates.
 But under the lecture's simplifying assumptions, the reinvestment effect
 does not distort prices, so the two delivery prices coincide:
 
-$\displaystyle F_{\text{forward}}(t,T)=F_{\text{future}}(t,T)=F(t,T).$
+$F_{\mathrm{forward}}(t,T)=F_{\mathrm{future}}(t,T)=F(t,T).$
 
 So for this course, forwards and futures can be priced using the same
 no-arbitrage formula.

--- a/NUS/QF1100/summary/Lecture 07.md
+++ b/NUS/QF1100/summary/Lecture 07.md
@@ -469,26 +469,26 @@ For a long futures position held from time $0$ to maturity $T$, the accrued
 profit at time $T$ is:
 
 $$
-A_T^{\text{long}} = \sum_{i=1}^{N} \left[F(i)-F(i-1)\right]R^{N-i}
+A_T^{\text{long}} = \sum_{i=1}^{N} \left(F(i)-F(i-1)\right)R^{N-i}
 $$
 
 For a position with contract size $Q$, multiply by $Q$:
 
 $$
-QA_T^{\text{long}} = Q\sum_{i=1}^{N} \left[F(i)-F(i-1)\right]R^{N-i}
+QA_T^{\text{long}} = Q\sum_{i=1}^{N} \left(F(i)-F(i-1)\right)R^{N-i}
 $$
 
 For a short futures position, the accrued profit is:
 
 $$
-A_T^{\text{short}} = -\sum_{i=1}^{N} \left[F(i)-F(i-1)\right]R^{N-i}
+A_T^{\text{short}} = -\sum_{i=1}^{N} \left(F(i)-F(i-1)\right)R^{N-i}
 $$
 
 If the interest rate is zero, then $R=1$ and the long futures profit
 telescopes:
 
 $$
-A_T^{\text{long}} = \sum_{i=1}^{N} \left[F(i)-F(i-1)\right] = F(N)-F(0)
+A_T^{\text{long}} = \sum_{i=1}^{N} \left(F(i)-F(i-1)\right) = F(N)-F(0)
 $$
 
 Since $F(N)=S(T)$ at maturity:

--- a/NUS/QF1100/summary/Lecture 07.md
+++ b/NUS/QF1100/summary/Lecture 07.md
@@ -162,22 +162,16 @@ happens later at time $T$.
 Under the lecture's assumption, the contract costs nothing to enter at
 time $t$. So:
 
-$$
-\text{profit} = \text{payoff} - \text{initial cost} = \text{payoff}.
-$$
+$\displaystyle \text{profit} = \text{payoff} - \text{initial cost} = \text{payoff}.$
 
 If you are long, you agree to buy at price $F(t,T)$. At maturity, the
 asset is worth $S_T$ in the market, so your net gain is:
 
-$$
-S_T-F(t,T)
-$$
+$\displaystyle S_T-F(t,T)$
 
 If you are short, you agree to sell at price $F(t,T)$, so your gain is:
 
-$$
-F(t,T)-S_T
-$$
+$\displaystyle F(t,T)-S_T$
 
 This also explains the sign:
 
@@ -278,22 +272,16 @@ strategies:
 If you buy the asset now using borrowed money at risk-free rate $r$, then
 the time-$T$ cost of that strategy is:
 
-$$
-S_0 e^{rT}
-$$
+$\displaystyle S_0 e^{rT}$
 
 No arbitrage says the forward delivery price must match that carrying
 cost, so:
 
-$$
-F(0,T)=S_0e^{rT}
-$$
+$\displaystyle F(0,T)=S_0e^{rT}$
 
 The same logic at a later time $t$ gives:
 
-$$
-F(t,T)=S_t e^{r(T-t)}.
-$$
+$\displaystyle F(t,T)=S_t e^{r(T-t)}.$
 
 Another way to see this is by arbitrage bounds:
 
@@ -456,16 +444,12 @@ For a long position:
 
 That is why the daily cash flow is:
 
-$$
-F(i)-F(i-1)
-$$
+$\displaystyle F(i)-F(i-1)$
 
 At maturity, the futures contract becomes a contract for immediate
 delivery, so the futures price must equal the spot price:
 
-$$
-F(N)=F(T)=S(T)
-$$
+$\displaystyle F(N)=F(T)=S(T)$
 
 If they differed, an investor could lock in an arbitrage by combining a
 futures position with immediate spot-market trading.
@@ -538,24 +522,18 @@ paid early has financing consequences too.
 That is why accrued profit is not just the sum of daily cash flows, but
 the accumulated value of those cash flows at time $T$:
 
-$$
-A_T^{\text{long}}=\sum_{i=1}^{N}[F(i)-F(i-1)]R^{N-i}
-$$
+$\displaystyle A_T^{\text{long}}=\sum_{i=1}^{N}[F(i)-F(i-1)]R^{N-i}$
 
 The factor $R^{N-i}$ means the cash flow received on day $i$ is carried
 forward for the remaining $N-i$ days until maturity.
 
 If $r=0$, then $R=1$, so the expression simplifies to a telescoping sum:
 
-$$
-[F(N)-F(N-1)] + \cdots + [F(1)-F(0)] = F(N)-F(0).
-$$
+$\displaystyle [F(N)-F(N-1)] + \cdots + [F(1)-F(0)] = F(N)-F(0).$
 
 Since $F(N)=S(T)$, the total futures profit becomes:
 
-$$
-A_T^{\text{long}}=S(T)-F(0),
-$$
+$\displaystyle A_T^{\text{long}}=S(T)-F(0),$
 
 which is exactly the long forward profit. This is the first hint of
 forward-futures equivalence.
@@ -604,9 +582,7 @@ at better rates.
 But under the lecture's simplifying assumptions, the reinvestment effect
 does not distort prices, so the two delivery prices coincide:
 
-$$
-F_{\text{forward}}(t,T)=F_{\text{future}}(t,T)=F(t,T).
-$$
+$\displaystyle F_{\text{forward}}(t,T)=F_{\text{future}}(t,T)=F(t,T).$
 
 So for this course, forwards and futures can be priced using the same
 no-arbitrage formula.

--- a/NUS/QF1100/summary/Lecture 08.md
+++ b/NUS/QF1100/summary/Lecture 08.md
@@ -1,0 +1,586 @@
+# Lecture 08
+
+This lecture explains how forwards and futures can be used to reduce or
+eliminate exposure to price risk.
+
+The main theme is:
+
+$$
+\text{hedge}=\text{position that offsets unwanted risk}
+$$
+
+## Variable Definitions
+
+$$
+t = \text{current time}
+$$
+
+$$
+T = \text{future date at which the exposure is realized or the hedge is closed}
+$$
+
+$$
+0 = \text{initial time}
+$$
+
+$$
+W = \text{number of units of the asset exposure}
+$$
+
+$$
+A,B = \text{asset being hedged and futures asset used for hedging}
+$$
+
+$$
+S_T = S_A(T) = \text{spot price of asset } A \text{ at time } T
+$$
+
+$$
+F_0 = F_B(0) = \text{futures price of asset } B \text{ at time } 0
+$$
+
+$$
+F_T = F_B(T) = \text{futures price of asset } B \text{ at time } T
+$$
+
+$$
+F(0,T) = \text{forward price agreed at time } 0 \text{ for delivery at } T
+$$
+
+$$
+h = \text{futures position size used in the hedge}
+$$
+
+$$
+y = y_T = \text{cash flow of the hedged position at time } T
+$$
+
+$$
+\beta = \frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)}
+= \text{optimal hedge ratio per unit of exposure}
+$$
+
+$$
+\rho_{S,F} = \operatorname{Corr}(S_T,F_T) \text{ when } \sigma_S,\sigma_F > 0
+$$
+
+$$
+\rho_{F,S}=\rho_{S,F}
+$$
+
+$$
+\sigma_S = \operatorname{SD}(S_T), \qquad
+\sigma_F = \operatorname{SD}(F_T), \qquad
+\sigma_y = \operatorname{SD}(y)
+$$
+
+$$
+\operatorname{Var}(S_T),\operatorname{Var}(F_T),\operatorname{Var}(y)
+= \text{variances of } S_T,\ F_T,\ \text{and } y
+$$
+
+$$
+\operatorname{Cov}(S_T,F_T)
+= \text{covariance between the spot exposure and the futures price}
+$$
+
+$$
+\operatorname{Corr}(S_T,F_T)
+= \text{correlation between the spot exposure and the futures price}
+$$
+
+$$
+\operatorname{basis} = \text{spot price of asset to be hedged}
+- \text{futures price of contract used}
+$$
+
+Unless otherwise stated, the minimum-variance hedge derivation assumes
+interest rates are zero.
+
+## Hedging with a Forward Contract
+
+Using a forward contract to hedge is conceptually straightforward:
+you lock in today the future buying or selling price of the asset.
+
+If you will sell the asset in the future, the risk is that the spot price
+falls. A short forward position offsets that risk.
+
+If you will buy the asset in the future, the risk is that the spot price
+rises. A long forward position offsets that risk.
+
+For a seller of $W$ units, the unhedged time-$T$ revenue is:
+
+$$
+WS_T
+$$
+
+If the seller shorts a forward for $W$ units at delivery price $F(0,T)$,
+the forward payoff is:
+
+$$
+W\bigl(F(0,T)-S_T\bigr)
+$$
+
+So the total hedged revenue is:
+
+$$
+WS_T + W\bigl(F(0,T)-S_T\bigr) = WF(0,T)
+$$
+
+For a buyer of $W$ units, the unhedged cost is:
+
+$$
+-WS_T
+$$
+
+If the buyer goes long a forward, the forward payoff is:
+
+$$
+W\bigl(S_T-F(0,T)\bigr)
+$$
+
+So the total hedged cash flow is:
+
+$$
+-WS_T + W\bigl(S_T-F(0,T)\bigr) = -WF(0,T)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A forward hedge works by replacing an unknown future spot price with a
+known delivery price.
+
+For a future seller:
+
+- without hedging, revenue is uncertain because it depends on $S_T$
+- with a short forward, the loss from a lower spot price is exactly offset
+  by a higher forward payoff
+
+That is why:
+
+$$
+WS_T + W(F(0,T)-S_T)=WF(0,T).
+$$
+
+For a future buyer, the same cancellation happens with opposite sign:
+
+$$
+-WS_T + W(S_T-F(0,T))=-WF(0,T).
+$$
+
+In both cases, the spot-price uncertainty disappears completely.
+
+The trade-off is that hedging removes downside risk but also gives up the
+upside benefit from a favorable price move.
+</details>
+
+## Perfect Hedge with Futures
+
+The primary use of futures contracts is to hedge against risk.
+
+A perfect hedge completely eliminates the risk associated with a future
+commitment to deliver or receive an asset by taking an opposite position
+in the futures market.
+
+Here "opposite" means opposite to the direction of risk:
+
+- a future buyer hedges by taking a long futures position;
+- a future seller hedges by taking a short futures position.
+
+The lecture notes that a perfect hedge is only possible if:
+
+- the delivery date of the asset matches the relevant futures date;
+- the asset being hedged matches the futures underlying exactly;
+- the amount hedged is an integral multiple of the futures contract size;
+- the futures market is liquid enough.
+
+If these conditions fail, risk may still be reduced, but not fully
+eliminated.
+
+<details>
+<summary>Intuition / proof</summary>
+
+A perfect hedge means the risky part of the original position and the risky
+part of the futures position cancel exactly.
+
+For example:
+
+- if you must buy later, rising prices hurt you, so you want a hedge that
+  profits when prices rise
+- if you must sell later, falling prices hurt you, so you want a hedge that
+  profits when prices fall
+
+That is why the "opposite position" is defined relative to price risk, not
+simply by whether you are buying or selling in the spot market.
+
+The hedge is called perfect only when the risky part cancels exactly, not
+merely approximately. That is why matching maturity, underlying asset, and
+contract size matters so much.
+</details>
+
+## Basis
+
+One measure of hedging imperfection is the basis:
+
+$$
+\operatorname{basis}
+= \text{spot price of asset to be hedged}
+- \text{futures price of contract used}
+$$
+
+Basis measures the mismatch between the asset exposure and the futures
+contract used in the hedge.
+
+If the hedged asset is identical to the futures underlying, then at the
+delivery date the basis is zero because spot and futures prices coincide.
+
+<details>
+<summary>Intuition / proof</summary>
+
+If the hedge were perfect, the futures price used for hedging would move
+exactly with the spot price exposure.
+
+Basis tells you how far reality is from that ideal.
+
+- small basis means the hedge tracks the exposure closely
+- large or unstable basis means the hedge leaves more residual risk
+
+So basis risk is the core reason why a hedge using a related but different
+futures contract may fail to eliminate risk completely.
+</details>
+
+## Minimum-Variance Hedge
+
+When a perfect hedge is unavailable, the goal is no longer to make the
+cash flow riskless. Instead, the goal is to choose the futures position
+that makes the cash flow as stable as possible.
+
+Suppose you have an obligation to purchase $W$ units of asset $A$ at
+time $T$, but only futures on asset $B$ are available.
+
+Assume the cash flow of the hedged position is:
+
+$$
+y = -WS_T + h(F_T-F_0)
+$$
+
+Here:
+
+- $-WS_T$ is the cost of buying the asset at time $T$;
+- $h(F_T-F_0)$ is the profit from the futures position.
+
+The variance of the cash flow is:
+
+$$
+\operatorname{Var}(y)
+= W^2\operatorname{Var}(S_T)
+- 2W\operatorname{Cov}(S_T,F_T)h
++ \operatorname{Var}(F_T)h^2
+$$
+
+This is a quadratic function of $h$.
+
+To minimize the risk, differentiate with respect to $h$ and set the
+result equal to zero:
+
+$$
+-2W\operatorname{Cov}(S_T,F_T)
++ 2\operatorname{Var}(F_T)h = 0
+$$
+
+Hence the minimum-variance hedge is:
+
+$$
+h
+= W\frac{\operatorname{Cov}(S_T,F_T)}
+{\operatorname{Var}(F_T)}
+$$
+
+Using correlation and standard deviations, when $\sigma_F > 0$,
+
+$$
+h
+= W\rho_{S,F}\frac{\sigma_S}{\sigma_F}
+$$
+
+The optimal hedge ratio per unit of exposure, when
+$\operatorname{Var}(F_T)>0$, is:
+
+$$
+\beta
+= \frac{\operatorname{Cov}(S_T,F_T)}
+{\operatorname{Var}(F_T)}
+$$
+
+so:
+
+$$
+h = W\beta
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The unhedged position has random cash flow because $S_T$ is random.
+Adding futures introduces another random term, $h(F_T-F_0)$.
+
+We choose $h$ so that the futures profit moves in the direction that best
+offsets the original exposure.
+
+The algebra comes from:
+
+$$
+y=-WS_T+hF_T-hF_0.
+$$
+
+Since $F_0$ is known at time $0$, it is a constant, so it does not affect
+variance. Therefore:
+
+$$
+\operatorname{Var}(y)=\operatorname{Var}(-WS_T+hF_T).
+$$
+
+Expanding with
+$\operatorname{Var}(aX+bY)=a^2\operatorname{Var}(X)+b^2\operatorname{Var}(Y)+2ab\operatorname{Cov}(X,Y)$
+gives:
+
+$$
+\operatorname{Var}(y)
+=W^2\operatorname{Var}(S_T)+h^2\operatorname{Var}(F_T)-2Wh\operatorname{Cov}(S_T,F_T).
+$$
+
+Because this is a quadratic in $h$ with positive coefficient
+$\operatorname{Var}(F_T)$, its minimum occurs where the derivative is zero.
+
+The formula
+
+$$
+h=W\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)}
+$$
+
+has a natural interpretation:
+
+- if $S_T$ and $F_T$ move together strongly, covariance is large, so the
+  hedge should be larger
+- if futures prices are very volatile on their own, $\operatorname{Var}(F_T)$
+  is large, so fewer futures are needed for the same offsetting effect
+
+This is exactly the same logic as choosing the slope coefficient in a
+linear least-squares fit: find the multiple of futures price changes that
+best explains the spot exposure.
+</details>
+
+## Minimum Variance and Hedge Effectiveness
+
+Substituting the optimal $h$ into the variance formula gives:
+
+$$
+\operatorname{Var}(y)
+= W^2\operatorname{Var}(S_T)
+- \frac{W^2\operatorname{Cov}(S_T,F_T)^2}
+{\operatorname{Var}(F_T)}
+$$
+
+Equivalently:
+
+$$
+\operatorname{Var}(y)
+= W^2\operatorname{Var}(S_T)(1-\rho_{S,F}^2)
+$$
+
+Hence the resulting standard deviation is:
+
+$$
+\sigma_y
+= \sqrt{1-\rho_{S,F}^2}\,W\sigma_S
+$$
+
+The unhedged risk is:
+
+$$
+W\sigma_S
+$$
+
+So the hedge reduces risk by the factor:
+
+$$
+\sqrt{1-\rho_{S,F}^2}
+$$
+
+This factor measures hedge effectiveness.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The key determinant is the correlation between the spot exposure and the
+futures contract.
+
+- if $|\rho_{S,F}|$ is close to $1$, the futures contract tracks the
+  exposure closely, so the remaining risk is small
+- if $\rho_{S,F}$ is close to $0$, the futures contract does not move with
+  the exposure, so the hedge does little
+
+The term
+
+$$
+1-\rho_{S,F}^2
+$$
+
+is the fraction of variance that remains after optimal hedging.
+
+This comes from substituting
+
+$$
+\operatorname{Cov}(S_T,F_T)=\rho_{S,F}\sigma_S\sigma_F
+$$
+
+into the minimized variance formula:
+
+$$
+W^2\operatorname{Var}(S_T)
+- \frac{W^2\operatorname{Cov}(S_T,F_T)^2}{\operatorname{Var}(F_T)}
+= W^2\sigma_S^2-\frac{W^2\rho_{S,F}^2\sigma_S^2\sigma_F^2}{\sigma_F^2}.
+$$
+
+That simplifies to:
+
+$$
+W^2\sigma_S^2(1-\rho_{S,F}^2).
+$$
+
+So:
+
+- $\rho_{S,F}^2$ measures how much risk is explained or removed
+- $\sqrt{1-\rho_{S,F}^2}$ measures how much standard deviation remains
+</details>
+
+## Sign of the Hedge
+
+The formula
+
+$$
+h = W\beta
+$$
+
+was derived for an obligation to purchase $W$ units, with cash flow
+
+$$
+y = -WS_T + h(F_T-F_0)
+$$
+
+If instead you plan to sell $W$ units of the asset, then the spot exposure
+changes sign, and the hedge becomes:
+
+$$
+h = -W\beta
+$$
+
+Equivalently, the sign of $h$ automatically reflects both:
+
+- whether the exposure is a future purchase or a future sale;
+- whether $\rho_{S,F}$ is positive or negative.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The hedge sign must oppose the direction of risk.
+
+- if you will buy later, rising spot prices hurt you, so you want a futures
+  position that tends to profit when futures prices rise
+- if you will sell later, falling spot prices hurt you, so you want the
+  opposite sign
+
+Also, if the correlation is negative, then the futures contract already
+moves in the opposite direction of the exposure, so the sign of the hedge
+flips automatically through $\beta$.
+
+This is why the lecture’s strategy table depends on both:
+
+- whether the underlying exposure is a purchase or sale, and
+- whether correlation is positive or negative
+
+The sign of $\beta$ packages that information into one formula.
+</details>
+
+## Perfect Hedge as a Special Case
+
+Suppose the futures asset is identical to the spot asset being hedged.
+For the purchase-obligation setup used above, this gives:
+
+$$
+F_T = S_T
+$$
+
+Hence:
+
+$$
+\operatorname{Cov}(S_T,F_T)
+= \operatorname{Cov}(S_T,S_T)
+= \operatorname{Var}(S_T)
+$$
+
+Therefore:
+
+$$
+\beta = 1
+$$
+
+and:
+
+$$
+h = W
+$$
+
+The minimum variance becomes:
+
+$$
+\operatorname{Var}(y)=0
+$$
+
+So the hedge is perfect.
+
+If instead the exposure were a future sale, then the matching perfect
+hedge would have the opposite sign:
+
+$$
+h = -W
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+When the futures contract and the spot exposure are really the same risk,
+there is no basis mismatch left at the hedge date.
+
+Then one unit of futures offsets one unit of spot exposure, so the optimal
+hedge ratio becomes exactly $1$.
+
+In the formula:
+
+$$
+\beta=\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)},
+$$
+
+setting $F_T=S_T$ gives:
+
+$$
+\beta=\frac{\operatorname{Var}(S_T)}{\operatorname{Var}(S_T)}=1.
+$$
+
+Then the hedged cash flow becomes deterministic, so its variance is zero.
+
+This is why perfect hedges are best seen as a special case of the
+minimum-variance hedge where the correlation is effectively complete and
+the basis problem disappears.
+</details>
+
+## Key Takeaways
+
+- Hedging reduces unwanted price risk by adding an offsetting position.
+- Forward hedging locks in a known future buying or selling price.
+- A perfect futures hedge completely eliminates risk, but requires a very close match between exposure and contract.
+- Basis measures the mismatch between the spot exposure and the futures contract used.
+- Minimum-variance hedging chooses the futures position that minimizes the variance of the hedged cash flow.
+- The optimal hedge ratio is $\beta=\operatorname{Cov}(S_T,F_T)/\operatorname{Var}(F_T)$ when $\operatorname{Var}(F_T)>0$.
+- Hedge effectiveness depends on $\rho_{S,F}^2$: stronger absolute correlation means a better hedge.

--- a/NUS/QF1100/summary/Lecture 08.md
+++ b/NUS/QF1100/summary/Lecture 08.md
@@ -56,12 +56,11 @@ y = y_T = \text{cash flow of the hedged position at time } T
 $$
 
 $$
-\beta = \frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)}
-= \text{optimal hedge ratio per unit of exposure}
+\beta = \frac{\mathrm{Cov}(S_T,F_T)}{\mathrm{Var}(F_T)} = \text{optimal hedge ratio per unit of exposure}
 $$
 
 $$
-\rho_{S,F} = \operatorname{Corr}(S_T,F_T) \text{ when } \sigma_S,\sigma_F > 0
+\rho_{S,F} = \mathrm{Corr}(S_T,F_T) \text{ when } \sigma_S,\sigma_F > 0
 $$
 
 $$
@@ -69,29 +68,23 @@ $$
 $$
 
 $$
-\sigma_S = \operatorname{SD}(S_T), \qquad
-\sigma_F = \operatorname{SD}(F_T), \qquad
-\sigma_y = \operatorname{SD}(y)
+\sigma_S = \mathrm{SD}(S_T), \qquad \sigma_F = \mathrm{SD}(F_T), \qquad \sigma_y = \mathrm{SD}(y)
 $$
 
 $$
-\operatorname{Var}(S_T),\operatorname{Var}(F_T),\operatorname{Var}(y)
-= \text{variances of } S_T,\ F_T,\ \text{and } y
+\mathrm{Var}(S_T),\mathrm{Var}(F_T),\mathrm{Var}(y) = \text{variances of } S_T,\ F_T,\ \text{and } y
 $$
 
 $$
-\operatorname{Cov}(S_T,F_T)
-= \text{covariance between the spot exposure and the futures price}
+\mathrm{Cov}(S_T,F_T) = \text{covariance between the spot exposure and the futures price}
 $$
 
 $$
-\operatorname{Corr}(S_T,F_T)
-= \text{correlation between the spot exposure and the futures price}
+\mathrm{Corr}(S_T,F_T) = \text{correlation between the spot exposure and the futures price}
 $$
 
 $$
-\operatorname{basis} = \text{spot price of asset to be hedged}
-- \text{futures price of contract used}
+\mathrm{basis} = \text{spot price of asset to be hedged} - \text{futures price of contract used}
 $$
 
 Unless otherwise stated, the minimum-variance hedge derivation assumes
@@ -220,9 +213,7 @@ contract size matters so much.
 One measure of hedging imperfection is the basis:
 
 $$
-\operatorname{basis}
-= \text{spot price of asset to be hedged}
-- \text{futures price of contract used}
+\mathrm{basis} = \text{spot price of asset to be hedged} - \text{futures price of contract used}
 $$
 
 Basis measures the mismatch between the asset exposure and the futures
@@ -269,10 +260,7 @@ Here:
 The variance of the cash flow is:
 
 $$
-\operatorname{Var}(y)
-= W^2\operatorname{Var}(S_T)
-- 2W\operatorname{Cov}(S_T,F_T)h
-+ \operatorname{Var}(F_T)h^2
+\mathrm{Var}(y) = W^2\mathrm{Var}(S_T) - 2W\mathrm{Cov}(S_T,F_T)h + \mathrm{Var}(F_T)h^2
 $$
 
 This is a quadratic function of $h$.
@@ -281,32 +269,26 @@ To minimize the risk, differentiate with respect to $h$ and set the
 result equal to zero:
 
 $$
--2W\operatorname{Cov}(S_T,F_T)
-+ 2\operatorname{Var}(F_T)h = 0
+-2W\mathrm{Cov}(S_T,F_T) + 2\mathrm{Var}(F_T)h = 0
 $$
 
 Hence the minimum-variance hedge is:
 
 $$
-h
-= W\frac{\operatorname{Cov}(S_T,F_T)}
-{\operatorname{Var}(F_T)}
+h = W\frac{\mathrm{Cov}(S_T,F_T)} {\mathrm{Var}(F_T)}
 $$
 
 Using correlation and standard deviations, when $\sigma_F > 0$,
 
 $$
-h
-= W\rho_{S,F}\frac{\sigma_S}{\sigma_F}
+h = W\rho_{S,F}\frac{\sigma_S}{\sigma_F}
 $$
 
 The optimal hedge ratio per unit of exposure, when
-$\operatorname{Var}(F_T)>0$, is:
+$\mathrm{Var}(F_T)>0$, is:
 
 $$
-\beta
-= \frac{\operatorname{Cov}(S_T,F_T)}
-{\operatorname{Var}(F_T)}
+\beta = \frac{\mathrm{Cov}(S_T,F_T)} {\mathrm{Var}(F_T)}
 $$
 
 so:
@@ -363,24 +345,19 @@ best explains the spot exposure.
 Substituting the optimal $h$ into the variance formula gives:
 
 $$
-\operatorname{Var}(y)
-= W^2\operatorname{Var}(S_T)
-- \frac{W^2\operatorname{Cov}(S_T,F_T)^2}
-{\operatorname{Var}(F_T)}
+\mathrm{Var}(y) = W^2\mathrm{Var}(S_T) - \frac{W^2\mathrm{Cov}(S_T,F_T)^2} {\mathrm{Var}(F_T)}
 $$
 
 Equivalently:
 
 $$
-\operatorname{Var}(y)
-= W^2\operatorname{Var}(S_T)(1-\rho_{S,F}^2)
+\mathrm{Var}(y) = W^2\mathrm{Var}(S_T)(1-\rho_{S,F}^2)
 $$
 
 Hence the resulting standard deviation is:
 
 $$
-\sigma_y
-= \sqrt{1-\rho_{S,F}^2}\,W\sigma_S
+\sigma_y = \sqrt{1-\rho_{S,F}^2}\,W\sigma_S
 $$
 
 The unhedged risk is:
@@ -492,9 +469,7 @@ $$
 Hence:
 
 $$
-\operatorname{Cov}(S_T,F_T)
-= \operatorname{Cov}(S_T,S_T)
-= \operatorname{Var}(S_T)
+\mathrm{Cov}(S_T,F_T) = \mathrm{Cov}(S_T,S_T) = \mathrm{Var}(S_T)
 $$
 
 Therefore:
@@ -512,7 +487,7 @@ $$
 The minimum variance becomes:
 
 $$
-\operatorname{Var}(y)=0
+\mathrm{Var}(y)=0
 $$
 
 So the hedge is perfect.
@@ -555,5 +530,5 @@ the basis problem disappears.
 - A perfect futures hedge completely eliminates risk, but requires a very close match between exposure and contract.
 - Basis measures the mismatch between the spot exposure and the futures contract used.
 - Minimum-variance hedging chooses the futures position that minimizes the variance of the hedged cash flow.
-- The optimal hedge ratio is $\beta=\operatorname{Cov}(S_T,F_T)/\operatorname{Var}(F_T)$ when $\operatorname{Var}(F_T)>0$.
+- The optimal hedge ratio is $\beta=\mathrm{Cov}(S_T,F_T)/\mathrm{Var}(F_T)$ when $\mathrm{Var}(F_T)>0$.
 - Hedge effectiveness depends on $\rho_{S,F}^2$: stronger absolute correlation means a better hedge.

--- a/NUS/QF1100/summary/Lecture 08.md
+++ b/NUS/QF1100/summary/Lecture 08.md
@@ -159,15 +159,11 @@ For a future seller:
 
 That is why:
 
-$$
-WS_T + W(F(0,T)-S_T)=WF(0,T).
-$$
+$\displaystyle WS_T + W(F(0,T)-S_T)=WF(0,T).$
 
 For a future buyer, the same cancellation happens with opposite sign:
 
-$$
--WS_T + W(S_T-F(0,T))=-WF(0,T).
-$$
+$\displaystyle -WS_T + W(S_T-F(0,T))=-WF(0,T).$
 
 In both cases, the spot-price uncertainty disappears completely.
 
@@ -330,34 +326,25 @@ offsets the original exposure.
 
 The algebra comes from:
 
-$$
-y=-WS_T+hF_T-hF_0.
-$$
+$\displaystyle y=-WS_T+hF_T-hF_0.$
 
 Since $F_0$ is known at time $0$, it is a constant, so it does not affect
 variance. Therefore:
 
-$$
-\operatorname{Var}(y)=\operatorname{Var}(-WS_T+hF_T).
-$$
+$\displaystyle \operatorname{Var}(y)=\operatorname{Var}(-WS_T+hF_T).$
 
 Expanding with
 $\operatorname{Var}(aX+bY)=a^2\operatorname{Var}(X)+b^2\operatorname{Var}(Y)+2ab\operatorname{Cov}(X,Y)$
 gives:
 
-$$
-\operatorname{Var}(y)
-=W^2\operatorname{Var}(S_T)+h^2\operatorname{Var}(F_T)-2Wh\operatorname{Cov}(S_T,F_T).
-$$
+$\displaystyle \operatorname{Var}(y) =W^2\operatorname{Var}(S_T)+h^2\operatorname{Var}(F_T)-2Wh\operatorname{Cov}(S_T,F_T).$
 
 Because this is a quadratic in $h$ with positive coefficient
 $\operatorname{Var}(F_T)$, its minimum occurs where the derivative is zero.
 
 The formula
 
-$$
-h=W\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)}
-$$
+$\displaystyle h=W\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)}$
 
 has a natural interpretation:
 
@@ -423,31 +410,21 @@ futures contract.
 
 The term
 
-$$
-1-\rho_{S,F}^2
-$$
+$\displaystyle 1-\rho_{S,F}^2$
 
 is the fraction of variance that remains after optimal hedging.
 
 This comes from substituting
 
-$$
-\operatorname{Cov}(S_T,F_T)=\rho_{S,F}\sigma_S\sigma_F
-$$
+$\displaystyle \operatorname{Cov}(S_T,F_T)=\rho_{S,F}\sigma_S\sigma_F$
 
 into the minimized variance formula:
 
-$$
-W^2\operatorname{Var}(S_T)
-- \frac{W^2\operatorname{Cov}(S_T,F_T)^2}{\operatorname{Var}(F_T)}
-= W^2\sigma_S^2-\frac{W^2\rho_{S,F}^2\sigma_S^2\sigma_F^2}{\sigma_F^2}.
-$$
+$\displaystyle W^2\operatorname{Var}(S_T) - \frac{W^2\operatorname{Cov}(S_T,F_T)^2}{\operatorname{Var}(F_T)} = W^2\sigma_S^2-\frac{W^2\rho_{S,F}^2\sigma_S^2\sigma_F^2}{\sigma_F^2}.$
 
 That simplifies to:
 
-$$
-W^2\sigma_S^2(1-\rho_{S,F}^2).
-$$
+$\displaystyle W^2\sigma_S^2(1-\rho_{S,F}^2).$
 
 So:
 
@@ -558,15 +535,11 @@ hedge ratio becomes exactly $1$.
 
 In the formula:
 
-$$
-\beta=\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)},
-$$
+$\displaystyle \beta=\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)},$
 
 setting $F_T=S_T$ gives:
 
-$$
-\beta=\frac{\operatorname{Var}(S_T)}{\operatorname{Var}(S_T)}=1.
-$$
+$\displaystyle \beta=\frac{\operatorname{Var}(S_T)}{\operatorname{Var}(S_T)}=1.$
 
 Then the hedged cash flow becomes deterministic, so its variance is zero.
 

--- a/NUS/QF1100/summary/Lecture 08.md
+++ b/NUS/QF1100/summary/Lecture 08.md
@@ -159,11 +159,11 @@ For a future seller:
 
 That is why:
 
-$\displaystyle WS_T + W(F(0,T)-S_T)=WF(0,T).$
+$WS_T + W(F(0,T)-S_T)=WF(0,T).$
 
 For a future buyer, the same cancellation happens with opposite sign:
 
-$\displaystyle -WS_T + W(S_T-F(0,T))=-WF(0,T).$
+$-WS_T + W(S_T-F(0,T))=-WF(0,T).$
 
 In both cases, the spot-price uncertainty disappears completely.
 
@@ -326,31 +326,31 @@ offsets the original exposure.
 
 The algebra comes from:
 
-$\displaystyle y=-WS_T+hF_T-hF_0.$
+$y=-WS_T+hF_T-hF_0.$
 
 Since $F_0$ is known at time $0$, it is a constant, so it does not affect
 variance. Therefore:
 
-$\displaystyle \operatorname{Var}(y)=\operatorname{Var}(-WS_T+hF_T).$
+$\mathrm{Var}(y)=\mathrm{Var}(-WS_T+hF_T).$
 
 Expanding with
-$\operatorname{Var}(aX+bY)=a^2\operatorname{Var}(X)+b^2\operatorname{Var}(Y)+2ab\operatorname{Cov}(X,Y)$
+$\mathrm{Var}(aX+bY)=a^2\mathrm{Var}(X)+b^2\mathrm{Var}(Y)+2ab\mathrm{Cov}(X,Y)$
 gives:
 
-$\displaystyle \operatorname{Var}(y) =W^2\operatorname{Var}(S_T)+h^2\operatorname{Var}(F_T)-2Wh\operatorname{Cov}(S_T,F_T).$
+$\mathrm{Var}(y) =W^2\mathrm{Var}(S_T)+h^2\mathrm{Var}(F_T)-2Wh\mathrm{Cov}(S_T,F_T).$
 
 Because this is a quadratic in $h$ with positive coefficient
-$\operatorname{Var}(F_T)$, its minimum occurs where the derivative is zero.
+$\mathrm{Var}(F_T)$, its minimum occurs where the derivative is zero.
 
 The formula
 
-$\displaystyle h=W\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)}$
+$h=W\frac{\mathrm{Cov}(S_T,F_T)}{\mathrm{Var}(F_T)}$
 
 has a natural interpretation:
 
 - if $S_T$ and $F_T$ move together strongly, covariance is large, so the
   hedge should be larger
-- if futures prices are very volatile on their own, $\operatorname{Var}(F_T)$
+- if futures prices are very volatile on their own, $\mathrm{Var}(F_T)$
   is large, so fewer futures are needed for the same offsetting effect
 
 This is exactly the same logic as choosing the slope coefficient in a
@@ -410,21 +410,21 @@ futures contract.
 
 The term
 
-$\displaystyle 1-\rho_{S,F}^2$
+$1-\rho_{S,F}^2$
 
 is the fraction of variance that remains after optimal hedging.
 
 This comes from substituting
 
-$\displaystyle \operatorname{Cov}(S_T,F_T)=\rho_{S,F}\sigma_S\sigma_F$
+$\mathrm{Cov}(S_T,F_T)=\rho_{S,F}\sigma_S\sigma_F$
 
 into the minimized variance formula:
 
-$\displaystyle W^2\operatorname{Var}(S_T) - \frac{W^2\operatorname{Cov}(S_T,F_T)^2}{\operatorname{Var}(F_T)} = W^2\sigma_S^2-\frac{W^2\rho_{S,F}^2\sigma_S^2\sigma_F^2}{\sigma_F^2}.$
+$W^2\mathrm{Var}(S_T) - \frac{W^2\mathrm{Cov}(S_T,F_T)^2}{\mathrm{Var}(F_T)} = W^2\sigma_S^2-\frac{W^2\rho_{S,F}^2\sigma_S^2\sigma_F^2}{\sigma_F^2}.$
 
 That simplifies to:
 
-$\displaystyle W^2\sigma_S^2(1-\rho_{S,F}^2).$
+$W^2\sigma_S^2(1-\rho_{S,F}^2).$
 
 So:
 
@@ -535,11 +535,11 @@ hedge ratio becomes exactly $1$.
 
 In the formula:
 
-$\displaystyle \beta=\frac{\operatorname{Cov}(S_T,F_T)}{\operatorname{Var}(F_T)},$
+$\beta=\frac{\mathrm{Cov}(S_T,F_T)}{\mathrm{Var}(F_T)},$
 
 setting $F_T=S_T$ gives:
 
-$\displaystyle \beta=\frac{\operatorname{Var}(S_T)}{\operatorname{Var}(S_T)}=1.$
+$\beta=\frac{\mathrm{Var}(S_T)}{\mathrm{Var}(S_T)}=1.$
 
 Then the hedged cash flow becomes deterministic, so its variance is zero.
 

--- a/NUS/QF1100/summary/Lecture 09.md
+++ b/NUS/QF1100/summary/Lecture 09.md
@@ -55,8 +55,7 @@ $$
 $$
 
 $$
-TV_T(C),\ TV_T(P)
-= \text{time-}T \text{ values of the call and put premiums}
+TV_T(C),\ TV_T(P) = \text{time-}T \text{ values of the call and put premiums}
 $$
 
 $$
@@ -100,13 +99,11 @@ C_{\text{node}} = \text{option value at a generic binomial node}
 $$
 
 $$
-C_{\text{up}},\ C_{\text{down}}
-= \text{option values at the two child nodes of a given node}
+C_{\text{up}},\ C_{\text{down}} = \text{option values at the two child nodes of a given node}
 $$
 
 $$
-C_{uu}, C_{ud}, C_{dd}
-= \text{option values at later binomial nodes}
+C_{uu}, C_{ud}, C_{dd} = \text{option values at later binomial nodes}
 $$
 
 $$
@@ -419,11 +416,7 @@ Using calls, it is formed by:
 Ignoring premiums, the payoff is:
 
 $$
-\begin{cases}
-0, & S_T \le K_1, \\
-S_T-K_1, & K_1 < S_T < K_2, \\
-K_2-K_1, & S_T \ge K_2.
-\end{cases}
+\begin{cases} 0, & S_T \le K_1, \\ S_T-K_1, & K_1 < S_T < K_2, \\ K_2-K_1, & S_T \ge K_2. \end{cases}
 $$
 
 <details>
@@ -489,12 +482,7 @@ The strategy is:
 Ignoring premiums, the payoff is:
 
 $$
-\begin{cases}
-0, & S_T \le K_1, \\
-S_T-K_1, & K_1 < S_T \le K_2, \\
-K_3-S_T, & K_2 < S_T < K_3, \\
-0, & S_T \ge K_3.
-\end{cases}
+\begin{cases} 0, & S_T \le K_1, \\ S_T-K_1, & K_1 < S_T \le K_2, \\ K_3-S_T, & K_2 < S_T < K_3, \\ 0, & S_T \ge K_3. \end{cases}
 $$
 
 <details>
@@ -777,8 +765,7 @@ backward one node at a time.
 At each node:
 
 $$
-C_{\text{node}}
-= \frac{1}{R}\left(qC_{\text{up}}+(1-q)C_{\text{down}}\right)
+C_{\text{node}} = \frac{1}{R}\left(qC_{\text{up}}+(1-q)C_{\text{down}}\right)
 $$
 
 For two periods:

--- a/NUS/QF1100/summary/Lecture 09.md
+++ b/NUS/QF1100/summary/Lecture 09.md
@@ -159,7 +159,7 @@ The crucial difference between a forward and an option is obligation.
 
 That is why option payoffs use the positive-part operator:
 
-$\displaystyle x^+=\max(x,0).$
+$x^+=\max(x,0).$
 
 If exercising would create a loss, the holder simply does not exercise.
 
@@ -268,7 +268,7 @@ Profit also accounts for what you paid or received at time $0$.
 
 For a long call, for example:
 
-$\displaystyle \text{profit}=\text{call payoff}-\text{time-}T \text{ value of premium}.$
+profit = call payoff - time-$T$ value of premium.
 
 The short position always has the opposite payoff and opposite profit from
 the corresponding long position.
@@ -369,7 +369,7 @@ that can dominate it.
 
 For the call, if
 
-$\displaystyle C < S_0-DK,$
+$C < S_0-DK,$
 
 then one can:
 
@@ -383,7 +383,7 @@ investment is enough to leave positive profit.
 
 For the put, if
 
-$\displaystyle P < DK-S_0,$
+$P < DK-S_0,$
 
 then one can:
 
@@ -613,7 +613,7 @@ Consider two portfolios:
 
 Their present values are:
 
-$\displaystyle PV_A=C+DK,\qquad PV_B=P+S_0.$
+$PV_A=C+DK$ and $PV_B=P+S_0$.
 
 At maturity:
 
@@ -696,7 +696,7 @@ no-arbitrage equivalent valuation rule.
 
 The condition
 
-$\displaystyle u>R>d$
+$u>R>d$
 
 prevents trivial arbitrage between the stock and the risk-free asset.
 
@@ -707,12 +707,12 @@ stock instead of lending risk-free.
 
 The quantity
 
-$\displaystyle q=\frac{R-d}{u-d}$
+$q=\frac{R-d}{u-d}$
 
 is not the real probability of an up move. It is the pricing weight that
 makes the discounted expected stock price under $q$ match no-arbitrage:
 
-$\displaystyle S=\frac{1}{R}\bigl(quS+(1-q)dS\bigr).$
+$S=\frac{1}{R}(quS+(1-q)dS).$
 
 That is why the option price depends on $q$, not on the real-world
 probability $p$.
@@ -757,14 +757,14 @@ portfolio payoff matches the option payoff in both possible future states.
 
 Once:
 
-$\displaystyle ux+Rb=C_u, \qquad dx+Rb=C_d,$
+$ux+Rb=C_u$ and $dx+Rb=C_d$,
 
 the portfolio and the option are indistinguishable at maturity.
 By no-arbitrage, they must have the same current price.
 
 Solving the two linear equations gives:
 
-$\displaystyle x=\frac{C_u-C_d}{u-d},\qquad b=\frac{uC_d-dC_u}{R(u-d)}.$
+$x=\frac{C_u-C_d}{u-d}$ and $b=\frac{uC_d-dC_u}{R(u-d)}.$
 
 This is the core replication idea behind derivative pricing.
 </details>
@@ -842,7 +842,7 @@ $\sigma$.
 
 The relation
 
-$\displaystyle d=\frac{1}{u}$
+$d=\frac{1}{u}$
 
 makes the up and down moves multiplicatively symmetric, which is why an
 up move followed by a down move returns to the same node.

--- a/NUS/QF1100/summary/Lecture 09.md
+++ b/NUS/QF1100/summary/Lecture 09.md
@@ -159,9 +159,7 @@ The crucial difference between a forward and an option is obligation.
 
 That is why option payoffs use the positive-part operator:
 
-$$
-x^+=\max(x,0).
-$$
+$\displaystyle x^+=\max(x,0).$
 
 If exercising would create a loss, the holder simply does not exercise.
 
@@ -270,9 +268,7 @@ Profit also accounts for what you paid or received at time $0$.
 
 For a long call, for example:
 
-$$
-\text{profit}=\text{call payoff}-\text{time-}T \text{ value of premium}.
-$$
+$\displaystyle \text{profit}=\text{call payoff}-\text{time-}T \text{ value of premium}.$
 
 The short position always has the opposite payoff and opposite profit from
 the corresponding long position.
@@ -373,9 +369,7 @@ that can dominate it.
 
 For the call, if
 
-$$
-C < S_0-DK,
-$$
+$\displaystyle C < S_0-DK,$
 
 then one can:
 
@@ -389,9 +383,7 @@ investment is enough to leave positive profit.
 
 For the put, if
 
-$$
-P < DK-S_0,
-$$
+$\displaystyle P < DK-S_0,$
 
 then one can:
 
@@ -621,9 +613,7 @@ Consider two portfolios:
 
 Their present values are:
 
-$$
-PV_A=C+DK,\qquad PV_B=P+S_0.
-$$
+$\displaystyle PV_A=C+DK,\qquad PV_B=P+S_0.$
 
 At maturity:
 
@@ -706,9 +696,7 @@ no-arbitrage equivalent valuation rule.
 
 The condition
 
-$$
-u>R>d
-$$
+$\displaystyle u>R>d$
 
 prevents trivial arbitrage between the stock and the risk-free asset.
 
@@ -719,16 +707,12 @@ stock instead of lending risk-free.
 
 The quantity
 
-$$
-q=\frac{R-d}{u-d}
-$$
+$\displaystyle q=\frac{R-d}{u-d}$
 
 is not the real probability of an up move. It is the pricing weight that
 makes the discounted expected stock price under $q$ match no-arbitrage:
 
-$$
-S=\frac{1}{R}\bigl(quS+(1-q)dS\bigr).
-$$
+$\displaystyle S=\frac{1}{R}\bigl(quS+(1-q)dS\bigr).$
 
 That is why the option price depends on $q$, not on the real-world
 probability $p$.
@@ -773,19 +757,14 @@ portfolio payoff matches the option payoff in both possible future states.
 
 Once:
 
-$$
-ux+Rb=C_u, \qquad dx+Rb=C_d,
-$$
+$\displaystyle ux+Rb=C_u, \qquad dx+Rb=C_d,$
 
 the portfolio and the option are indistinguishable at maturity.
 By no-arbitrage, they must have the same current price.
 
 Solving the two linear equations gives:
 
-$$
-x=\frac{C_u-C_d}{u-d},\qquad
-b=\frac{uC_d-dC_u}{R(u-d)}.
-$$
+$\displaystyle x=\frac{C_u-C_d}{u-d},\qquad b=\frac{uC_d-dC_u}{R(u-d)}.$
 
 This is the core replication idea behind derivative pricing.
 </details>
@@ -863,9 +842,7 @@ $\sigma$.
 
 The relation
 
-$$
-d=\frac{1}{u}
-$$
+$\displaystyle d=\frac{1}{u}$
 
 makes the up and down moves multiplicatively symmetric, which is why an
 up move followed by a down move returns to the same node.

--- a/NUS/QF1100/summary/Lecture 09.md
+++ b/NUS/QF1100/summary/Lecture 09.md
@@ -1,0 +1,886 @@
+# Lecture 09
+
+This lecture introduces options, option payoffs and profits, no-arbitrage
+bounds, option trading strategies, put-call parity, and binomial option
+pricing.
+
+## Variable Definitions
+
+$$
+t = \text{current time}
+$$
+
+$$
+T = \text{expiration date or maturity date}
+$$
+
+$$
+S_0 = \text{current price of the underlying asset}
+$$
+
+$$
+S_T = \text{price of the underlying asset at maturity}
+$$
+
+$$
+S = S_0 = \text{current stock price in the binomial model}
+$$
+
+$$
+K = \text{strike price or exercise price}
+$$
+
+$$
+C = \text{current price of a European call option}
+$$
+
+$$
+P = \text{current price of a European put option}
+$$
+
+$$
+\text{premium} = \text{up-front fee paid by the holder to the writer}
+$$
+
+$$
+\text{holder} = \text{buyer of the option contract}
+$$
+
+$$
+\text{writer} = \text{seller of the option contract}
+$$
+
+$$
+\text{exercise} = \text{holder's act of using the option right}
+$$
+
+$$
+TV_T(C),\ TV_T(P)
+= \text{time-}T \text{ values of the call and put premiums}
+$$
+
+$$
+D = \text{discount factor from time } T \text{ to time } 0
+$$
+
+$$
+r = \text{risk-free interest rate under the compounding convention used in the current section}
+$$
+
+$$
+x^+ = \max(x,0)
+$$
+
+$$
+K_1,K_2,K_3 = \text{different strike prices used in spread strategies}
+$$
+
+$$
+u,d = \text{up and down stock-price factors in the binomial model}
+$$
+
+$$
+R = 1+r = \text{one-period risk-free accumulation factor in the binomial section}
+$$
+
+$$
+p = \text{real-world probability of an up move}
+$$
+
+$$
+q = \frac{R-d}{u-d} = \text{risk-neutral probability}
+$$
+
+$$
+C_u,\ C_d = \text{option values in the up and down child states of a one-step binomial pricing step}
+$$
+
+$$
+C_{\text{node}} = \text{option value at a generic binomial node}
+$$
+
+$$
+C_{\text{up}},\ C_{\text{down}}
+= \text{option values at the two child nodes of a given node}
+$$
+
+$$
+C_{uu}, C_{ud}, C_{dd}
+= \text{option values at later binomial nodes}
+$$
+
+$$
+x = \text{dollars invested in the stock in the replicating portfolio}
+$$
+
+$$
+b = \text{dollars invested in the risk-free asset in the replicating portfolio}
+$$
+
+$$
+\sigma = \text{annualized volatility in the CRR model}
+$$
+
+$$
+\Delta t = \text{length of one time step in the CRR model}
+$$
+
+$$
+PV_A,\ PV_B = \text{present values of the two portfolios used in put-call parity}
+$$
+
+Unless otherwise stated, the lecture assumes European options on one unit
+of a non-dividend-paying underlying asset.
+
+## Options
+
+An option is a contract that gives the holder the right, but not the
+obligation, to buy or sell an underlying asset under specified terms.
+
+A call option gives the holder the right to buy the underlying asset.
+
+A put option gives the holder the right to sell the underlying asset.
+
+The holder is the buyer of the option. The writer is the seller of the
+option.
+
+Exercise is the act of using the option right:
+
+- a call holder pays $K$ to buy the asset;
+- a put holder sells the asset and receives $K$.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The crucial difference between a forward and an option is obligation.
+
+- a forward forces both parties to transact at maturity
+- an option lets the holder choose whether exercising is favorable
+
+That is why option payoffs use the positive-part operator:
+
+$$
+x^+=\max(x,0).
+$$
+
+If exercising would create a loss, the holder simply does not exercise.
+
+That is why an option has asymmetric payoff: the downside is truncated at
+zero, but favorable outcomes are still kept.
+</details>
+
+## European and American Options
+
+A European option can be exercised only at maturity.
+
+An American option can be exercised at any time up to maturity.
+
+Unless stated otherwise, the lecture assumes European options.
+
+<details>
+<summary>Intuition / proof</summary>
+
+European versus American affects timing, not the basic payoff formula.
+
+- European: exercise only at time $T$
+- American: exercise any time up to $T$
+
+European options are easier to price, which is why the lecture develops
+pricing theory in that setting.
+
+For this lecture, European options are especially convenient because all
+payoff comparisons happen at one common date, namely maturity.
+</details>
+
+## Payoffs at Maturity
+
+The payoff of a European call at maturity is:
+
+$$
+(S_T-K)^+ = \max(S_T-K,0)
+$$
+
+The payoff of a European put at maturity is:
+
+$$
+(K-S_T)^+ = \max(K-S_T,0)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+For a call:
+
+- if $S_T \le K$, buying at strike $K$ is not attractive, so the holder
+  does not exercise and payoff is $0$
+- if $S_T > K$, the holder buys at $K$ and receives something worth $S_T$,
+  so payoff is $S_T-K$
+
+For a put:
+
+- if $S_T \ge K$, selling at strike $K$ is not attractive, so payoff is $0$
+- if $S_T < K$, the holder can sell for $K$ something worth only $S_T$, so
+  payoff is $K-S_T$
+
+This is exactly why the call payoff is increasing in $S_T$, while the put
+payoff is decreasing in $S_T$.
+
+It also explains why calls benefit from high final stock prices, while puts
+benefit from low final stock prices.
+</details>
+
+## Option Positions and Profits
+
+A long option position means buying the option.
+
+A short option position means writing, or selling, the option.
+
+If the premium is paid at time $0$, then profit at time $T$ equals payoff
+minus the time value of the premium.
+
+Long call profit:
+
+$$
+\max(S_T-K,0) - TV_T(C)
+$$
+
+Long put profit:
+
+$$
+\max(K-S_T,0) - TV_T(P)
+$$
+
+Short call profit:
+
+$$
+-\max(S_T-K,0) + TV_T(C)
+$$
+
+Short put profit:
+
+$$
+-\max(K-S_T,0) + TV_T(P)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Payoff tells you what the option itself produces at maturity.
+Profit also accounts for what you paid or received at time $0$.
+
+For a long call, for example:
+
+$$
+\text{profit}=\text{call payoff}-\text{time-}T \text{ value of premium}.
+$$
+
+The short position always has the opposite payoff and opposite profit from
+the corresponding long position.
+
+This is why an option can have positive payoff but still negative profit:
+the payoff may be too small to recover the premium paid upfront.
+</details>
+
+## Upper Bounds for European Option Prices
+
+Assume:
+
+- no transaction costs;
+- the same tax rate for all investors;
+- borrowing and lending are possible at the risk-free rate;
+- the underlying asset pays no dividends.
+
+Then the no-arbitrage upper bounds are:
+
+$$
+C \le S_0
+$$
+
+$$
+P \le DK
+$$
+
+With continuous compounding:
+
+$$
+D = e^{-rT}
+$$
+
+so:
+
+$$
+P \le Ke^{-rT}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A call cannot be worth more than the stock itself, because owning the
+stock gives at least as much upside as owning the right to buy the stock
+later.
+
+If $C>S_0$, one could:
+
+- buy the stock for $S_0$
+- sell the call for $C$
+
+to receive positive cash now, and at maturity the stock position always
+covers the call obligation.
+
+A put cannot be worth more than the present value of $K$, because the most
+a put can ever deliver at maturity is $K$.
+
+If $P>DK$, one could:
+
+- write the put
+- invest the premium proceeds at the risk-free rate
+
+Since the worst possible maturity obligation is paying $K$, the invested
+proceeds are enough to cover it and still leave arbitrage profit.
+</details>
+
+## Lower Bounds for European Option Prices
+
+The call lower bound is:
+
+$$
+C \ge \max(0,S_0-DK)
+$$
+
+With continuous compounding:
+
+$$
+C \ge \max(0,S_0-Ke^{-rT})
+$$
+
+The put lower bound is:
+
+$$
+P \ge \max(0,DK-S_0)
+$$
+
+With continuous compounding:
+
+$$
+P \ge \max(0,Ke^{-rT}-S_0)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The lower bounds say an option cannot be too cheap relative to a portfolio
+that can dominate it.
+
+For the call, if
+
+$$
+C < S_0-DK,
+$$
+
+then one can:
+
+- short the stock and receive $S_0$
+- buy the call for $C$
+- invest the difference $S_0-C$
+
+At maturity, either the call is exercised to close the short stock
+position, or the stock is bought in the market. In both cases, the
+investment is enough to leave positive profit.
+
+For the put, if
+
+$$
+P < DK-S_0,
+$$
+
+then one can:
+
+- borrow enough money to buy the stock and the put
+- buy the stock
+- buy the put
+
+At maturity, either the put is exercised for $K$ or the stock itself is
+worth at least $K$, so the final cash flow covers the loan and leaves
+positive profit.
+</details>
+
+## Trading Strategies
+
+A principal-protected note combines a zero-coupon bond with a call option.
+The bond protects principal, while the call provides upside exposure.
+
+A spread is a strategy involving two or more options of the same type.
+
+A combination is a strategy involving both calls and puts.
+
+## Bull Spread
+
+A bull spread profits from an increase in the underlying price, but with
+limited upside and limited downside.
+
+Using calls, it is formed by:
+
+- buying one call with lower strike $K_1$;
+- selling one call with higher strike $K_2$;
+- assuming $K_1<K_2$.
+
+Ignoring premiums, the payoff is:
+
+$$
+\begin{cases}
+0, & S_T \le K_1, \\
+S_T-K_1, & K_1 < S_T < K_2, \\
+K_2-K_1, & S_T \ge K_2.
+\end{cases}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The long low-strike call benefits from price increases first.
+The short high-strike call starts offsetting gains only after the stock
+moves above $K_2$.
+
+So the payoff:
+
+- is flat when the stock stays too low
+- rises between $K_1$ and $K_2$
+- becomes capped at $K_2-K_1$
+
+This is why a bull spread expresses a moderately bullish view, not an
+unlimited-upside view.
+</details>
+
+## Bear Spread
+
+A bear spread profits from a decrease in the underlying price, but both
+gain and loss are limited.
+
+It can be formed using either calls or puts, and its payoff moves in the
+opposite direction of a bull spread.
+
+<details>
+<summary>Intuition / proof</summary>
+
+A bear spread is the mirror image of a bull spread.
+
+Instead of benefiting from moderate increases in price, it benefits from
+moderate decreases in price.
+
+Its payoff is still bounded, which is why it represents a directional view
+with limited risk and limited reward.
+</details>
+
+## Butterfly Spread
+
+A butterfly spread is useful when the investor expects the underlying
+price to stay near a middle strike.
+
+Using calls, let:
+
+$$
+K_1 < K_2 < K_3
+$$
+
+Usually:
+
+$$
+K_1 + K_3 = 2K_2
+$$
+
+The strategy is:
+
+- buy one call with strike $K_1$;
+- sell two calls with strike $K_2$;
+- buy one call with strike $K_3$.
+
+Ignoring premiums, the payoff is:
+
+$$
+\begin{cases}
+0, & S_T \le K_1, \\
+S_T-K_1, & K_1 < S_T \le K_2, \\
+K_3-S_T, & K_2 < S_T < K_3, \\
+0, & S_T \ge K_3.
+\end{cases}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+A butterfly spread is built to profit when the stock ends near the middle
+strike $K_2$.
+
+- the low-strike long call helps when the price rises toward the middle
+- the two short middle-strike calls hurt if the price moves too far beyond
+  the center
+- the high-strike long call limits the loss from very large upward moves
+
+So the payoff peaks in the middle and is small at both extremes.
+
+This is why butterfly spreads are useful when the investor expects little
+movement and wants to profit from the stock staying near a target range.
+</details>
+
+## Box Spread
+
+A box spread combines a bull spread and a bear spread using the same pair
+of strike prices.
+
+Its payoff is riskless, so its present value must equal the present value
+of the certain payoff. Otherwise, there is an arbitrage opportunity.
+
+<details>
+<summary>Intuition / proof</summary>
+
+Because a box spread creates a fixed payoff at maturity, it behaves like a
+synthetic zero-coupon bond.
+
+So no-arbitrage says its current price must equal the present value of that
+fixed maturity payoff.
+
+If the market price differed, one could buy the cheaper of the box spread
+and the matching risk-free payoff and sell the more expensive one.
+</details>
+
+## Covered Call, Protective Put, and Long Straddle
+
+A covered call is formed by holding the underlying asset and writing a
+call option on it.
+
+Ignoring premiums, its payoff is:
+
+$$
+S_T-(S_T-K)^+ = \min(S_T,K)
+$$
+
+A protective put is formed by holding the underlying asset and buying a
+put option on it.
+
+Ignoring premiums, its payoff is:
+
+$$
+S_T+(K-S_T)^+ = \max(S_T,K)
+$$
+
+A long straddle is formed by buying a call and a put with the same strike
+and maturity.
+
+Ignoring premiums, its payoff is:
+
+$$
+(S_T-K)^+ + (K-S_T)^+ = |S_T-K|
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+These strategies combine options with the stock to reshape risk:
+
+- a covered call sacrifices upside beyond $K$
+- a protective put creates a floor at $K$
+- a long straddle profits when the stock moves far away from $K$ in either
+  direction
+
+The formulas simplify because the option payoff either truncates the stock
+payoff above $K$, lifts it up to $K$, or measures distance from $K$.
+
+In particular, the straddle payoff becomes $|S_T-K|$, so it is small near
+the strike and large when the stock ends far away from the strike in either
+direction.
+</details>
+
+## Put-Call Parity
+
+For a European call and put on the same non-dividend-paying underlying,
+with the same strike $K$ and maturity $T$:
+
+$$
+C+DK = P+S_0
+$$
+
+With continuous compounding:
+
+$$
+D=e^{-rT}
+$$
+
+so:
+
+$$
+C+Ke^{-rT}=P+S_0
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+Consider two portfolios:
+
+- Portfolio A: one call plus a zero-coupon bond paying $K$ at time $T$
+- Portfolio B: one put plus one share of stock
+
+Their present values are:
+
+$$
+PV_A=C+DK,\qquad PV_B=P+S_0.
+$$
+
+At maturity:
+
+- if $S_T \ge K$, Portfolio A pays $S_T-K+K=S_T$, while Portfolio B pays
+  $0+S_T=S_T$
+- if $S_T < K$, Portfolio A pays $0+K=K$, while Portfolio B pays
+  $K-S_T+S_T=K$
+
+So both portfolios have the same payoff in every state.
+By the law of one price, they must have the same present value, which
+gives put-call parity.
+
+This is the cleanest example in the lecture of pricing by payoff
+equivalence: same future payoff implies same present value.
+</details>
+
+## Single-Period Binomial Model
+
+Let the stock price today be:
+
+$$
+S=S_0
+$$
+
+After one period, it moves either up to $uS$ or down to $dS$, where:
+
+$$
+u>d>0
+$$
+
+Let:
+
+$$
+R=1+r
+$$
+
+Here, $r$ is the one-period effective risk-free rate, so $R$ is the
+one-period accumulation factor.
+
+For no-arbitrage, the lecture requires:
+
+$$
+u>R>d
+$$
+
+For a call option, the one-period up-state and down-state option values
+are terminal payoffs:
+
+$$
+C_u=\max(uS-K,0)
+$$
+
+$$
+C_d=\max(dS-K,0)
+$$
+
+The one-period call price is:
+
+$$
+C=\frac{1}{R}\left(qC_u+(1-q)C_d\right)
+$$
+
+where:
+
+$$
+q=\frac{R-d}{u-d}
+$$
+
+Important point:
+
+$$
+q \ne p \text{ in general}
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The binomial model prices the option by replacing uncertain payoffs with a
+no-arbitrage equivalent valuation rule.
+
+The condition
+
+$$
+u>R>d
+$$
+
+prevents trivial arbitrage between the stock and the risk-free asset.
+
+If $R\ge u$, even the up state of the stock underperforms the bank account,
+so one could short the stock and invest risk-free. If $d\ge R$, even the
+down state does not underperform the bank account, so one could buy the
+stock instead of lending risk-free.
+
+The quantity
+
+$$
+q=\frac{R-d}{u-d}
+$$
+
+is not the real probability of an up move. It is the pricing weight that
+makes the discounted expected stock price under $q$ match no-arbitrage:
+
+$$
+S=\frac{1}{R}\bigl(quS+(1-q)dS\bigr).
+$$
+
+That is why the option price depends on $q$, not on the real-world
+probability $p$.
+</details>
+
+## Replicating Portfolio
+
+The one-period option price can also be found by building a portfolio
+that replicates the option payoff.
+
+Let:
+
+$$
+ux+Rb=C_u
+$$
+
+$$
+dx+Rb=C_d
+$$
+
+Solving gives:
+
+$$
+x=\frac{C_u-C_d}{u-d}
+$$
+
+$$
+b=\frac{uC_d-dC_u}{R(u-d)}
+$$
+
+Therefore:
+
+$$
+C=x+b
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The idea is to choose holdings in stock and the risk-free asset so that the
+portfolio payoff matches the option payoff in both possible future states.
+
+Once:
+
+$$
+ux+Rb=C_u, \qquad dx+Rb=C_d,
+$$
+
+the portfolio and the option are indistinguishable at maturity.
+By no-arbitrage, they must have the same current price.
+
+Solving the two linear equations gives:
+
+$$
+x=\frac{C_u-C_d}{u-d},\qquad
+b=\frac{uC_d-dC_u}{R(u-d)}.
+$$
+
+This is the core replication idea behind derivative pricing.
+</details>
+
+## Multi-Period Binomial Pricing
+
+For multiple periods, first compute option payoffs at maturity, then work
+backward one node at a time.
+
+At each node:
+
+$$
+C_{\text{node}}
+= \frac{1}{R}\left(qC_{\text{up}}+(1-q)C_{\text{down}}\right)
+$$
+
+For two periods:
+
+$$
+C_u=\frac{1}{R}\left(qC_{uu}+(1-q)C_{ud}\right)
+$$
+
+$$
+C_d=\frac{1}{R}\left(qC_{ud}+(1-q)C_{dd}\right)
+$$
+
+Then:
+
+$$
+C=\frac{1}{R}\left(qC_u+(1-q)C_d\right)
+$$
+
+<details>
+<summary>Intuition / proof</summary>
+
+The same one-step pricing logic applies at every node of the tree.
+
+So the pricing procedure is:
+
+1. compute terminal payoffs at maturity
+2. move backward one step at a time
+3. apply the one-period pricing formula at each node
+
+This backward induction is the main computational method for binomial
+option pricing.
+
+Because the tree recombines, many different paths can lead to the same
+intermediate node, which keeps the calculation manageable.
+</details>
+
+## CRR Binomial Model
+
+In the Cox-Ross-Rubinstein model:
+
+$$
+u=e^{\sigma\sqrt{\Delta t}}
+$$
+
+$$
+d=\frac{1}{u}
+$$
+
+As $\Delta t \to 0$, the CRR binomial model approaches the
+Black-Scholes model.
+
+The lecture notes that Black-Scholes itself is not required for the final
+exam.
+
+<details>
+<summary>Intuition / proof</summary>
+
+The CRR model chooses the up and down factors so that the tree recombines
+neatly and the one-step volatility matches the intended volatility level
+$\sigma$.
+
+The relation
+
+$$
+d=\frac{1}{u}
+$$
+
+makes the up and down moves multiplicatively symmetric, which is why an
+up move followed by a down move returns to the same node.
+
+As the time step $\Delta t$ gets smaller, the CRR tree becomes a finer and
+finer approximation to continuous-time option pricing.
+</details>
+
+## Key Takeaways
+
+- A call payoff is $(S_T-K)^+$ and a put payoff is $(K-S_T)^+$.
+- Profit equals payoff adjusted for the time-0 premium.
+- No-arbitrage gives the option price bounds and put-call parity.
+- A bull spread has limited upside and downside; a butterfly spread peaks near the middle strike.
+- In the binomial model, no-arbitrage requires $u>R>d$.
+- The risk-neutral probability is $q=\frac{R-d}{u-d}$, and in general it is not the real-world probability.
+- Binomial option pricing can be done either by risk-neutral valuation or by replication.
+- In the CRR model, $u=e^{\sigma\sqrt{\Delta t}}$ and $d=1/u$.


### PR DESCRIPTION
## Summary

This PR adds and refines the QF1100 lecture summaries under `NUS/QF1100/summary`.

It includes Lecture 01 through Lecture 09, with the notes copied into this branch and then cleaned up for readability and GitHub rendering.

## Changes

- Added the QF1100 lecture summary files for Lectures 01-09
- Standardized the lecture naming to `Lecture 01` through `Lecture 09`
- Removed local file references from the notes
- Normalized math formatting for GitHub rendering
- Kept the `Intuition / proof` sections collapsible while making their math syntax more renderer-friendly
- Replaced renderer-sensitive syntax such as `\operatorname` and bracket-style delimiters where needed
- Adjusted a few notation issues and phrasing details in the lecture notes